### PR TITLE
Update tagging in open editors, and implement tests

### DIFF
--- a/src/Extension/Rosie/Annotation/RosieHighlightActionsSourceProvider.cs
+++ b/src/Extension/Rosie/Annotation/RosieHighlightActionsSourceProvider.cs
@@ -4,11 +4,9 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Extension.Rosie.Model;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 
@@ -74,8 +72,8 @@ namespace Extension.Rosie.Annotation
         }
 
         /// <summary>
-        /// Lightbulb actions are available only when the inspected <c>range</c> is not empty and
-        /// there is at least one <see cref="RosieViolationTag"/> present in that range.
+        /// Lightbulb actions are available only when there is at least one <see cref="RosieViolationTag"/> present
+        /// in the inspected range.
         /// </summary>
         public Task<bool> HasSuggestedActionsAsync(ISuggestedActionCategorySet requestedActionCategories,
             SnapshotSpan range, CancellationToken cancellationToken)
@@ -86,7 +84,7 @@ namespace Extension.Rosie.Annotation
         }
 
         /// <summary>
-        /// Collects the lightbulb actions for the given <c>range</c>.
+        /// Collects the lightbulb actions for the given <c>range</c>, where range can empty too.
         /// <br/>
         /// The tags for a given range are retrieved via <c>_violationTagAggregator</c>.
         /// <br/>
@@ -101,7 +99,7 @@ namespace Extension.Rosie.Annotation
             SnapshotSpan range,
             CancellationToken cancellationToken)
         {
-            if (range.IsEmpty || _isDisposed)
+            if (_isDisposed)
                 return Enumerable.Empty<SuggestedActionSet>();
 
             var violationsInRange = _violationTagAggregator.GetTags(range);
@@ -121,9 +119,8 @@ namespace Extension.Rosie.Annotation
             return new[]
             {
                 new SuggestedActionSet(null,
-                    suggestedActions.ToArray(),
-                    null,
-                    SuggestedActionSetPriority.Medium)
+                    suggestedActions,
+                    priority: SuggestedActionSetPriority.Medium)
             };
         }
 

--- a/src/Extension/Rosie/CodigaCodeAnalysisConfig.cs
+++ b/src/Extension/Rosie/CodigaCodeAnalysisConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Extension.Rosie
 {
@@ -9,5 +10,19 @@ namespace Extension.Rosie
     public class CodigaCodeAnalysisConfig
     {
         public List<string>? Rulesets { get; set; }
+
+        /// <summary>
+        /// Returns the ruleset names having filtered out null values from them.
+        /// <br/>
+        /// This is for covering the case where the config file is configured like this:
+        /// <code>
+        /// rulesets:
+        ///   - 
+        /// </code>
+        /// </summary>
+        public List<string>? GetRulesets()
+        {
+            return Rulesets?.Where(ruleset => ruleset != null).ToList();
+        }
     }
 }

--- a/src/Extension/Rosie/CodigaConfigFileUtil.cs
+++ b/src/Extension/Rosie/CodigaConfigFileUtil.cs
@@ -20,6 +20,7 @@ namespace Extension.Rosie
         private static readonly IDeserializer ConfigDeserializer = new DeserializerBuilder()
             .WithNamingConvention(LowerCaseNamingConvention.Instance)
             .Build();
+
         /// <summary>
         /// Combines the following validations for the ruleset name:
         /// - it must be at least 5 characters long
@@ -29,6 +30,7 @@ namespace Extension.Rosie
         /// </summary>
         /// <seealso cref="https://regexr.com/730qs"/>
         private static readonly Regex CodigaRulesetNamePattern = new Regex("^[a-z0-9][a-z0-9-]{4,31}$");
+
         private const string CodigaConfigFileName = "codiga.yml";
 
         /// <summary>
@@ -87,7 +89,7 @@ namespace Extension.Rosie
         {
             if (string.IsNullOrWhiteSpace(rawYamlConfig))
                 return null;
-            
+
             try
             {
                 return ConfigDeserializer.Deserialize<CodigaCodeAnalysisConfig>(rawYamlConfig);

--- a/src/Extension/Rosie/Model/RosieRule.cs
+++ b/src/Extension/Rosie/Model/RosieRule.cs
@@ -29,6 +29,10 @@ namespace Extension.Rosie.Model
         }
 
         private string? ElementCheckedToRosieEntityChecked(string? elementChecked) {
+            if (elementChecked == null) {
+                return null;
+            }
+            
             return elementChecked switch
             {
                 "ForLoop" => EntityCheckedForLoop,

--- a/src/Extension/Rosie/Model/RosieRule.cs
+++ b/src/Extension/Rosie/Model/RosieRule.cs
@@ -4,13 +4,13 @@ namespace Extension.Rosie.Model
 {
     public class RosieRule
     {
-        private const string ENTITY_CHECKED_FUNCTION_CALL = "functioncall";
-        private const string ENTITY_CHECKED_IF_CONDITION = "ifcondition";
-        private const string ENTITY_CHECKED_IMPORT = "import";
-        private const string ENTITY_CHECKED_ASSIGNMENT = "assign";
-        private const string ENTITY_CHECKED_FOR_LOOP = "forloop";
-        private const string ENTITY_CHECKED_FUNCTION_DEFINITION = "functiondefinition";
-        private const string ENTITY_CHECKED_TRY_BLOCK = "tryblock";
+        private const string EntityCheckedFunctionCall = "functioncall";
+        private const string EntityCheckedIfCondition = "ifcondition";
+        private const string EntityCheckedImport = "import";
+        private const string EntityCheckedAssignment = "assign";
+        private const string EntityCheckedForLoop = "forloop";
+        private const string EntityCheckedFunctionDefinition = "functiondefinition";
+        private const string EntityCheckedTryBlock = "tryblock";
         
         public string Id { get; }
         public string ContentBase64 { get; }
@@ -18,24 +18,6 @@ namespace Extension.Rosie.Model
         public string Type { get; }
         public string? EntityChecked { get; }
         public string Pattern { get; }
-        
-        private string? ElementCheckedToRosieEntityChecked(string? elementChecked) {
-            // if (elementChecked == null) {
-            //     return null;
-            // }
-
-            return elementChecked switch
-            {
-                "ForLoop" => ENTITY_CHECKED_FOR_LOOP,
-                "Assignment" => ENTITY_CHECKED_ASSIGNMENT,
-                "FunctionDefinition" => ENTITY_CHECKED_FUNCTION_DEFINITION,
-                "TryBlock" => ENTITY_CHECKED_TRY_BLOCK,
-                "Import" => ENTITY_CHECKED_IMPORT,
-                "IfCondition" => ENTITY_CHECKED_IF_CONDITION,
-                "FunctionCall" => ENTITY_CHECKED_FUNCTION_CALL,
-                _ => null
-            };
-        }
 
         public RosieRule(string rulesetName, Rule rule) {
             Id = rulesetName + "/" + rule.Name;
@@ -44,6 +26,20 @@ namespace Extension.Rosie.Model
             Type = rule.RuleType;
             EntityChecked = ElementCheckedToRosieEntityChecked(rule.ElementChecked);
             Pattern = rule.Pattern;
+        }
+
+        private string? ElementCheckedToRosieEntityChecked(string? elementChecked) {
+            return elementChecked switch
+            {
+                "ForLoop" => EntityCheckedForLoop,
+                "Assignment" => EntityCheckedAssignment,
+                "FunctionDefinition" => EntityCheckedFunctionDefinition,
+                "TryBlock" => EntityCheckedTryBlock,
+                "Import" => EntityCheckedImport,
+                "IfCondition" => EntityCheckedIfCondition,
+                "FunctionCall" => EntityCheckedFunctionCall,
+                _ => null
+            };
         }
     }
 }

--- a/src/Extension/Rosie/RosieClient.cs
+++ b/src/Extension/Rosie/RosieClient.cs
@@ -64,10 +64,11 @@ namespace Extension.Rosie
 
         public /*override*/ async Task<IList<RosieAnnotation>> GetAnnotations(ITextBuffer textBuffer)
         {
-            if (textBuffer.GetFileName() == null || !File.Exists(textBuffer.GetFileName()))
+            var fileName = textBuffer.GetFileName();
+            if (fileName == null || !File.Exists(fileName))
                 return NoAnnotation;
 
-            var language = LanguageUtils.ParseFromFileName(textBuffer.GetFileName());
+            var language = LanguageUtils.ParseFromFileName(fileName);
 
             if (!SupportedLanguages.Contains(language))
                 return NoAnnotation;
@@ -90,7 +91,7 @@ namespace Extension.Rosie
                 using (var httpClient = new HttpClient())
                 {
                     //Prepare the request and send it to the Rosie server
-                    var rosieRequest = new RosieRequest(Path.GetFileName(textBuffer.GetFileName()), RosieUtils.GetRosieLanguage(language),
+                    var rosieRequest = new RosieRequest(Path.GetFileName(fileName), RosieUtils.GetRosieLanguage(language),
                         "utf8",
                         codeBase64, rosieRules, true);
                     var userAgent = await GetUserAgentAsync();

--- a/src/Extension/Rosie/RosieRulesCache.cs
+++ b/src/Extension/Rosie/RosieRulesCache.cs
@@ -306,8 +306,12 @@ namespace Extension.Rosie
         /// <returns>The rules for the given language.</returns>
         public IReadOnlyList<RosieRule> GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration language)
         {
-            var cachedRules = _cachedRules[language];
-            return cachedRules != null ? cachedRules.RosieRules : NoRule;
+            if (_cachedRules.ContainsKey(language))
+            {
+                var cachedRules = _cachedRules[language];
+                return cachedRules != null ? cachedRules.RosieRules : NoRule;                
+            }
+            return NoRule;
         }
 
         /// <summary>

--- a/src/Extension/Rosie/RosieRulesCache.cs
+++ b/src/Extension/Rosie/RosieRulesCache.cs
@@ -229,7 +229,6 @@ namespace Extension.Rosie
                     }
 
                     UpdateCacheFrom(rulesetsForClient);
-                    CacheLastUpdatedTimeStamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
                     /*
                       Updating the local timestamp only if it has changed, because it may happen that
                       codiga.yml was updated locally with a non-existent ruleset, or a ruleset that has an earlier timestamp
@@ -275,7 +274,6 @@ namespace Extension.Rosie
                         return;
 
                     UpdateCacheFrom(rulesetsForClient);
-                    CacheLastUpdatedTimeStamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
                     RulesetslastUpdatedTimeStamp = timestampFromServer;
                     //Only notify when not in testing mode
                     if (_clientProvider is DefaultCodigaClientProvider)
@@ -313,6 +311,8 @@ namespace Extension.Rosie
             _cachedRules.Clear();
             foreach (var keyValuePair in rulesByLanguage)
                 _cachedRules.Add(keyValuePair.Key, keyValuePair.Value);
+            
+            CacheLastUpdatedTimeStamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         }
 
         /// <summary>

--- a/src/Extension/Rosie/RosieRulesCache.cs
+++ b/src/Extension/Rosie/RosieRulesCache.cs
@@ -128,7 +128,7 @@ namespace Extension.Rosie
         {
             while (true)
             {
-                switch (HandleCacheUpdate())
+                switch (await HandleCacheUpdateAsync())
                 {
                     case UpdateResult.NoCodigaClient:
                     {
@@ -164,7 +164,7 @@ namespace Extension.Rosie
             NoCodigaClient, NoConfigFile, Success 
         }
 
-        public UpdateResult HandleCacheUpdate()
+        public async Task<UpdateResult> HandleCacheUpdateAsync()
         {
             if (!_clientProvider.TryGetClient(out var client))
                 return UpdateResult.NoCodigaClient;
@@ -183,9 +183,9 @@ namespace Extension.Rosie
 
             //If the Codiga config file has changed (its last write time doesn't match its previous write time)
             if (ConfigFileLastWriteTime.CompareTo(File.GetLastWriteTime(codigaConfigFile)) != 0)
-                UpdateCacheFromModifiedCodigaConfigFile(codigaConfigFile, client);
+                await UpdateCacheFromModifiedCodigaConfigFileAsync(codigaConfigFile, client);
             else
-                UpdateCacheFromChangesOnServer(client);
+                await UpdateCacheFromChangesOnServerAsync(client);
 
             return UpdateResult.Success;
         }
@@ -193,7 +193,7 @@ namespace Extension.Rosie
         /// <summary>
         /// Handles when there was a change in the codiga.yml file.
         /// </summary>
-        private async void UpdateCacheFromModifiedCodigaConfigFile(string codigaConfigFile, ICodigaClient client)
+        private async Task UpdateCacheFromModifiedCodigaConfigFileAsync(string codigaConfigFile, ICodigaClient client)
         {
             ConfigFileLastWriteTime = File.GetLastWriteTime(codigaConfigFile);
             var rawCodigaConfig = File.ReadAllText(codigaConfigFile);
@@ -257,7 +257,7 @@ namespace Extension.Rosie
         /// <summary>
         /// Handles the case when the codiga.yml file is unchanged, but there might be change on the server.
         /// </summary>
-        private async void UpdateCacheFromChangesOnServer(ICodigaClient client)
+        private async Task UpdateCacheFromChangesOnServerAsync(ICodigaClient client)
         {
             if (RulesetNames.Count == 0)
                 return;

--- a/src/GraphQLClient/Model/Rosie/RuleSetsForClient.cs
+++ b/src/GraphQLClient/Model/Rosie/RuleSetsForClient.cs
@@ -3,19 +3,12 @@ using System.Collections.Generic;
 namespace GraphQLClient.Model.Rosie
 {
     /// <summary>
-    /// Represents the structure of a Codiga Ruleset
+    /// Represents the structure of a Codiga Ruleset.
     /// </summary>
     public class RuleSetsForClient
     {
         public long? Id { get; set; }
         public string? Name { get; set; }
         public IReadOnlyList<Rule>? Rules { get; set; }
-
-        public RuleSetsForClient(long? id, string? name, IReadOnlyList<Rule>? rules)
-        {
-            Id = id;
-            Name = name;
-            Rules = rules;
-        }
     }
 }

--- a/src/GraphQLClient/Model/Rosie/RuleSetsForClient.cs
+++ b/src/GraphQLClient/Model/Rosie/RuleSetsForClient.cs
@@ -10,5 +10,12 @@ namespace GraphQLClient.Model.Rosie
         public long? Id { get; set; }
         public string? Name { get; set; }
         public IReadOnlyList<Rule>? Rules { get; set; }
+
+        public RuleSetsForClient(long? id, string? name, IReadOnlyList<Rule>? rules)
+        {
+            Id = id;
+            Name = name;
+            Rules = rules;
+        }
     }
 }

--- a/src/Tests/Rosie/CodigaConfigFileUtilTest.cs
+++ b/src/Tests/Rosie/CodigaConfigFileUtilTest.cs
@@ -1,4 +1,7 @@
+using System.IO;
+using EnvDTE;
 using Extension.Rosie;
+using Moq;
 using NUnit.Framework;
 
 namespace Tests.Rosie
@@ -9,34 +12,37 @@ namespace Tests.Rosie
     [TestFixture]
     internal class CodigaConfigFileUtilTest
     {
+        private string _solutionDir;
+        private string _codigaConfigFile;
+
         #region DeserializeConfig negative cases
-        
+
         [Test]
         public void DeserializeConfig_should_return_null_for_null_raw_config()
         {
             var codigaConfigFile = CodigaConfigFileUtil.DeserializeConfig(null);
-            
+
             Assert.That(codigaConfigFile, Is.Null);
         }
-        
+
         [Test]
         public void DeserializeConfig_should_return_null_for_empty_raw_config()
         {
             var codigaConfigFile = CodigaConfigFileUtil.DeserializeConfig("");
-            
+
             Assert.That(codigaConfigFile, Is.Null);
         }
-        
+
         [Test]
         public void DeserializeConfig_should_return_null_for_whitespace_only_raw_config()
         {
             var codigaConfigFile = CodigaConfigFileUtil.DeserializeConfig("   ");
-            
+
             Assert.That(codigaConfigFile, Is.Null);
         }
-        
+
         #endregion
-        
+
         #region CollectRulesetNames positive cases
 
         [Test]
@@ -117,38 +123,79 @@ rulesets:
 not-rulesets:
   - my-csharp-ruleset
   - my-other-ruleset");
-        
+
             var rulesetNames = CodigaConfigFileUtil.CollectRulesetNames(codigaConfigFile);
-        
+
             Assert.That(rulesetNames, Is.Empty);
         }
-        
+
         [Test]
         public void CollectRulesetNames_should_return_no_ruleset_name_for_non_sequence_empty_rulesets_list()
         {
             var codigaConfigFile = CodigaConfigFileUtil.DeserializeConfig(@"
 rulesets:
   ");
-        
+
             var rulesetNames = CodigaConfigFileUtil.CollectRulesetNames(codigaConfigFile);
-        
+
             Assert.That(rulesetNames, Is.Empty);
         }
-        
+
         [Test]
         public void CollectRulesetNames_should_return_no_ruleset_name_for_non_sequence_rulesets_property()
         {
             var codigaConfigFile = CodigaConfigFileUtil.DeserializeConfig(@"
 rulesets:
   rules:");
-        
+
             var rulesetNames = CodigaConfigFileUtil.CollectRulesetNames(codigaConfigFile);
-        
+
             Assert.That(rulesetNames, Is.Empty);
         }
 
         #endregion
-        
+
+        #region FindCodigaConfigFile
+
+        [Test]
+        public void FindCodigaConfigFile_should_return_null_for_missing_solution_root()
+        {
+            var solution = new Mock<Solution>();
+
+            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(solution.Object);
+
+            Assert.That(configFile, Is.Null);
+        }
+
+        [Test]
+        public void FindCodigaConfigFile_should_return_null_for_missing_codiga_config_file()
+        {
+            var solution = new Mock<Solution>();
+            _solutionDir = Path.GetTempPath();
+            solution.Setup(s => s.FullName).Returns(_solutionDir);
+
+            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(solution.Object);
+
+            Assert.That(configFile, Is.Null);
+        }
+
+        [Test]
+        public void FindCodigaConfigFile_should_return_path_of_codiga_config_file()
+        {
+            _solutionDir = Path.GetTempPath();
+            _codigaConfigFile = $"{_solutionDir}codiga.yml";
+
+            var solution = new Mock<Solution>();
+            solution.Setup(s => s.FullName).Returns(_solutionDir);
+            using var fs = File.Create(_codigaConfigFile);
+
+            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(solution.Object);
+
+            Assert.That(configFile, Is.EqualTo(_codigaConfigFile));
+        }
+
+        #endregion
+
         #region Invalid ruleset names
 
         [Test]
@@ -179,7 +226,16 @@ rulesets:
         {
             return CodigaConfigFileUtil.IsRulesetNameValid(rulesetName);
         }
-        
+
         #endregion
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_solutionDir))
+                File.Delete(_solutionDir);
+            if (File.Exists(_codigaConfigFile))
+                File.Delete(_codigaConfigFile);
+        }
     }
 }

--- a/src/Tests/Rosie/RosieRulesCacheTest.cs
+++ b/src/Tests/Rosie/RosieRulesCacheTest.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using System.IO;
+using EnvDTE;
+using Extension.Caching;
+using Extension.Rosie;
+using Extension.SnippetFormats;
+using GraphQLClient;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests.Rosie
+{
+    /// <summary>
+    /// Unit test for <see cref="RosieRulesCache"/>.
+    /// </summary>
+    /// <seealso cref="https://www.codeproject.com/Articles/5286617/Moq-and-out-Parameter"/>
+    /// <seealso cref="https://stackoverflow.com/questions/1068095/assigning-out-ref-parameters-in-moq"/>
+    [TestFixture]
+    internal class RosieRulesCacheTest
+    {
+        private Mock<Solution> _solution;
+        private string _solutionDirPath;
+        private string _codigaConfigFile;
+
+        [SetUp]
+        public void Setup()
+        {
+            _solutionDirPath = Path.GetTempPath();
+            _codigaConfigFile = $"{_solutionDirPath}codiga.yml";
+
+            _solution = new Mock<Solution>();
+            _solution.Setup(s => s.FullName).Returns(_solutionDirPath);
+        }
+
+        #region HandleCacheUpdate
+
+        [Test]
+        public void HandleCacheUpdate_should_return_no_codiga_client_for_missing_codiga_client()
+        {
+            RosieRulesCache.Initialize(_solution.Object, new NoCodigaClientProvider());
+            var updateResult = RosieRulesCache.Instance.HandleCacheUpdate();
+
+            Assert.AreEqual(updateResult, RosieRulesCache.UpdateResult.NoCodigaClient);
+        }
+
+        [Test]
+        public void HandleCacheUpdate_should_clear_cache_and_return_no_config_file_for_missing_config_file()
+        {
+            //Configure a Codiga config file, and initialize the cache with some rules
+
+            InitCodigaConfig(@"
+rulesets:
+  - singleRulesetSingleLanguage");
+
+            var clientProvider = new TestCodigaClientProvider();
+            RosieRulesCache.Initialize(_solution.Object, clientProvider);
+
+            Assert.That(RosieRulesCache.IsInitializedWithRules, Is.False);
+
+            var cache = RosieRulesCache.Instance;
+            cache.HandleCacheUpdate();
+
+            //Delete the Codiga config file and try to update the cache
+
+            File.Delete(_codigaConfigFile);
+
+            var updateResult = cache.HandleCacheUpdate();
+
+            Assert.AreEqual(updateResult, RosieRulesCache.UpdateResult.NoConfigFile);
+            Assert.That(cache.RulesetNames, Is.Empty);
+            Assert.That(cache.GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration.Python),
+                Is.Empty);
+            Assert.That(RosieRulesCache.IsInitializedWithRules, Is.True);
+        }
+
+        [Test]
+        public void HandleCacheUpdate_should_populate_empty_cache_from_codiga_config_file()
+        {
+            InitCodigaConfig(@"
+rulesets:
+  - singleRulesetSingleLanguage");
+
+            var clientProvider = new TestCodigaClientProvider();
+            RosieRulesCache.Initialize(_solution.Object, clientProvider);
+            var cache = RosieRulesCache.Instance;
+
+            var updateResult = cache.HandleCacheUpdate();
+
+            Assert.AreEqual(updateResult, RosieRulesCache.UpdateResult.Success);
+
+            var rules = cache.GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration.Python);
+            Assert.That(rules[0].Id, Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule1.Name}"));
+            Assert.That(rules[1].Id, Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule2.Name}"));
+            Assert.That(rules[2].Id, Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule3.Name}"));
+        }
+
+        [Test]
+        public void HandleCacheUpdate_should_update_non_empty_cache_from_codiga_config_file()
+        {
+            InitCodigaConfig(@"
+rulesets:
+  - singleRulesetSingleLanguage");
+
+            var clientProvider = new TestCodigaClientProvider();
+            RosieRulesCache.Initialize(_solution.Object, clientProvider);
+            var cache = RosieRulesCache.Instance;
+
+            cache.HandleCacheUpdate();
+
+            var rules = cache.GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration.Python);
+            Assert.That(rules[0].Id, Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule1.Name}"));
+            Assert.That(rules[1].Id, Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule2.Name}"));
+            Assert.That(rules[2].Id, Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule3.Name}"));
+
+            UpdateCodigaConfig(@"
+rulesets:
+  - multipleRulesetsSingleLanguage");
+
+            var updateResult = cache.HandleCacheUpdate();
+
+            Assert.AreEqual(updateResult, RosieRulesCache.UpdateResult.Success);
+
+            var rulesMulti = cache.GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration.Python);
+            Assert.That(rulesMulti[0].Id,
+                Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule1.Name}"));
+            Assert.That(rulesMulti[1].Id,
+                Is.EqualTo($"python-ruleset/{RulesetsForClientTestSupport.PythonRule2.Name}"));
+            Assert.That(rulesMulti[2].Id,
+                Is.EqualTo($"python-ruleset-2/{RulesetsForClientTestSupport.PythonRule3.Name}"));
+        }
+
+        [Test]
+        public void HandleCacheUpdate_should_update_non_empty_cache_from_server()
+        {
+            InitCodigaConfig(@"
+rulesets:
+  - singleRulesetSingleLanguage");
+
+            var clientProvider = new TestCodigaClientProvider();
+            RosieRulesCache.Initialize(_solution.Object, clientProvider);
+            var cache = RosieRulesCache.Instance;
+
+            cache.UpdateCacheFrom(RulesetsForClientTestSupport.SingleRulesetMultipleLanguages());
+            cache.RulesetslastUpdatedTimeStamp = 102L;
+            cache.ConfigFileLastWriteTime = File.GetLastWriteTime(_codigaConfigFile);
+            cache.RulesetNames = new List<string> { "singleRulesetSingleLanguage" };
+
+            var rules = cache.GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration.Python);
+            Assert.That(rules.Count, Is.EqualTo(2));
+            Assert.That(cache.RulesetslastUpdatedTimeStamp, Is.EqualTo(102L));
+
+            cache.HandleCacheUpdate();
+
+            var updatedRules = cache.GetRosieRulesForLanguage(LanguageUtils.LanguageEnumeration.Python);
+            Assert.That(updatedRules.Count, Is.EqualTo(3));
+            Assert.That(cache.RulesetslastUpdatedTimeStamp, Is.EqualTo(101L));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private void InitCodigaConfig(string rawConfig)
+        {
+            File.WriteAllText(_codigaConfigFile, rawConfig);
+        }
+
+        private void UpdateCodigaConfig(string rawConfig)
+        {
+            InitCodigaConfig(rawConfig);
+        }
+
+        #endregion
+
+        [TearDown]
+        public void TearDown()
+        {
+            RosieRulesCache.Dispose();
+            File.Delete(_codigaConfigFile);
+        }
+
+        /// <summary>
+        /// A client provider whose <c>TryGetClient()</c> methods returns false to signal that there is no
+        /// client available.
+        /// </summary>
+        private class NoCodigaClientProvider : ICodigaClientProvider
+        {
+            public bool TryGetClient(out ICodigaClient client)
+            {
+                client = GetClient();
+                return false;
+            }
+
+            public ICodigaClient GetClient()
+            {
+                return new TestCodigaClient();
+            }
+        }
+    }
+}

--- a/src/Tests/Rosie/RosieRulesCacheTest.cs
+++ b/src/Tests/Rosie/RosieRulesCacheTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using EnvDTE;
 using Extension.Caching;
 using Extension.Rosie;
@@ -387,13 +388,15 @@ rulesets:
 
         private void InitCodigaConfig(string rawConfig)
         {
-            File.WriteAllText(_codigaConfigFile, rawConfig);
+            using var fs = File.Create(_codigaConfigFile);
+            var info = Encoding.UTF8.GetBytes(rawConfig);
+            fs.Write(info, 0, info.Length);
         }
 
         private void UpdateCodigaConfig(string rawConfig)
         {
             File.Delete(_codigaConfigFile);
-            File.WriteAllText(_codigaConfigFile, rawConfig);
+            InitCodigaConfig(rawConfig);
         }
 
         #endregion

--- a/src/Tests/Rosie/RosieRulesCacheTest.cs
+++ b/src/Tests/Rosie/RosieRulesCacheTest.cs
@@ -398,6 +398,20 @@ rulesets:
         private async Task UpdateCodigaConfig(string rawConfig)
         {
             File.Delete(_codigaConfigFile);
+            
+            //This delay ensures that the last write time of the new config file is different than the
+            // one in the rules cache. In the CI pipeline the test execution tends to be so fast
+            // that it is executed in the same millisecond, resulting in the exact same last write time. 
+            var task = Task.Delay(TimeSpan.FromMilliseconds(100));
+            try
+            {
+                await task;
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+            
             InitCodigaConfig(rawConfig);
         }
 

--- a/src/Tests/Rosie/RosieRulesCacheTest.cs
+++ b/src/Tests/Rosie/RosieRulesCacheTest.cs
@@ -392,7 +392,8 @@ rulesets:
 
         private void UpdateCodigaConfig(string rawConfig)
         {
-            InitCodigaConfig(rawConfig);
+            File.Delete(_codigaConfigFile);
+            File.WriteAllText(_codigaConfigFile, rawConfig);
         }
 
         #endregion
@@ -400,8 +401,8 @@ rulesets:
         [TearDown]
         public void TearDown()
         {
-            RosieRulesCache.Dispose();
             File.Delete(_codigaConfigFile);
+            RosieRulesCache.Dispose();
         }
 
         /// <summary>

--- a/src/Tests/Rosie/RosieUtilsTest.cs
+++ b/src/Tests/Rosie/RosieUtilsTest.cs
@@ -1,0 +1,29 @@
+using Extension.Rosie;
+using Extension.SnippetFormats;
+using NUnit.Framework;
+
+namespace Tests.Rosie
+{
+    /// <summary>
+    /// Unit test for <see cref="RosieUtils"/>.
+    /// </summary>
+    [TestFixture]
+    public class RosieUtilsTest
+    {
+        [Test]
+        public void GetRosieLanguage_should_return_language_string_for_supported_language()
+        {
+            var language = RosieUtils.GetRosieLanguage(LanguageUtils.LanguageEnumeration.Python);
+
+            Assert.That(language, Is.EqualTo("python"));
+        }
+        
+        [Test]
+        public void GetRosieLanguage_should_return_unknown_for_not_supported_language()
+        {
+            var language = RosieUtils.GetRosieLanguage(LanguageUtils.LanguageEnumeration.Apex);
+
+            Assert.That(language, Is.EqualTo("unknown"));
+        }
+    }
+}

--- a/src/Tests/Rosie/RulesetsForClientTestSupport.cs
+++ b/src/Tests/Rosie/RulesetsForClientTestSupport.cs
@@ -27,8 +27,19 @@ namespace Tests.Rosie
             "python_rule_3",
             "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGNvbnN0IGVycm9yID0gYnVpbGRFcnJvcihtb2RlLnN0YXJ0LmxpbmUsIG1vZGUuc3RhcnQuY29sLCBtb2RlLmVuZC5saW5lLCBtb2RlLmVuZC5jb2wsICJlcnJvciBtZXNzYWdlIiwgIkNSSVRJQ0FMIiwgInNlY3VyaXR5Iik7CiAgICBhZGRFcnJvcihlcnJvcik7CiAgfQp9",
             "Python");
+        
+        public static readonly Rule PythonRule4 = CreateAstRule(
+            30,
+            "python_rule_4",
+            "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKfQ==",
+        "Python");
+        public static readonly Rule PythonRule5 = CreateAstRule(
+            31,
+            "python_rule_5",
+            "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGNvbnN0IGVycm9yID0gYnVpbGRFcnJvcihtb2RlLnN0YXJ0LmxpbmUsIG1vZGUuc3RhcnQuY29sLCBtb2RlLmVuZC5saW5lLCBtb2RlLmVuZC5jb2wsICJlcnJvciBtZXNzYWdlIiwgIkNSSVRJQ0FMIiwgInNlY3VyaXR5Iik7CiAgICBhZGRFcnJvcihlcnJvcik7CiAgfQp9",
+        "Python");
 
-        private static readonly Rule JavaRule1 = CreateAstRule(
+        public static readonly Rule JavaRule1 = CreateAstRule(
             20L,
             "java_rule_1",
             "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGFkZEVycm9yKGJ1aWxkRXJyb3IobW9kZS5zdGFydC5saW5lLCBtb2RlLnN0YXJ0LmNvbCwgbW9kZS5lbmQubGluZSwgbW9kZS5lbmQuY29sLCAiZXJyb3IgbWVzc2FnZSIsICJDUklUSUNBTCIsICJzZWN1cml0eSIpKTsKICB9Cn0=",
@@ -48,15 +59,15 @@ namespace Tests.Rosie
             {
                 case "singleRulesetSingleLanguage":
                     return SingleRulesetSingleLanguage(); //Python
-                // case "singleRulesetMultipleLanguagesDefaultTimestamp":
+                case "singleRulesetMultipleLanguagesDefaultTimestamp":
                 case "singleRulesetMultipleLanguages":
                     return SingleRulesetMultipleLanguages(); //Python, Java
                 case "multipleRulesetsSingleLanguage":
                     return MultipleRulesetsSingleLanguage(); //Python
-                // case "multipleRulesetsMultipleLanguages":
-                //     return MultipleRulesetsMultipleLanguages(); //Python, Java
-                // case "erroredRuleset":
-                //     return null;
+                case "multipleRulesetsMultipleLanguages":
+                return MultipleRulesetsMultipleLanguages(); //Python, Java
+                    case "erroredRuleset":
+                    return null;
                 default:
                     return ImmutableList.Create<RuleSetsForClient>();
             }
@@ -72,7 +83,6 @@ namespace Tests.Rosie
                 "multipleRulesetsSingleLanguage" => 103L,
                 "multipleRulesetsMultipleLanguages" => 104L,
                 _ => -1L
-                // _ => null
             };
         }
 
@@ -106,6 +116,19 @@ namespace Tests.Rosie
 
             var ruleset = new RuleSetsForClient(1234, "python-ruleset", rules);
             var ruleset2 = new RuleSetsForClient(6789, "python-ruleset-2", rules2);
+
+            return ImmutableList.Create(ruleset, ruleset2);
+        }
+        
+        /// <summary>
+        /// Returns multiple rulesets with rules configured for different languages.
+        /// </summary>
+        public static IReadOnlyCollection<RuleSetsForClient> MultipleRulesetsMultipleLanguages() {
+            var rules = new List<Rule> { PythonRule4, JavaRule1 };
+            var rules2 = new List<Rule> { PythonRule5 };
+
+            var ruleset = new RuleSetsForClient(5678, "mixed-ruleset", rules);
+            var ruleset2 = new RuleSetsForClient(6789, "python-ruleset", rules2);
 
             return ImmutableList.Create(ruleset, ruleset2);
         }

--- a/src/Tests/Rosie/RulesetsForClientTestSupport.cs
+++ b/src/Tests/Rosie/RulesetsForClientTestSupport.cs
@@ -27,17 +27,18 @@ namespace Tests.Rosie
             "python_rule_3",
             "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGNvbnN0IGVycm9yID0gYnVpbGRFcnJvcihtb2RlLnN0YXJ0LmxpbmUsIG1vZGUuc3RhcnQuY29sLCBtb2RlLmVuZC5saW5lLCBtb2RlLmVuZC5jb2wsICJlcnJvciBtZXNzYWdlIiwgIkNSSVRJQ0FMIiwgInNlY3VyaXR5Iik7CiAgICBhZGRFcnJvcihlcnJvcik7CiAgfQp9",
             "Python");
-        
+
         public static readonly Rule PythonRule4 = CreateAstRule(
             30,
             "python_rule_4",
             "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKfQ==",
-        "Python");
+            "Python");
+
         public static readonly Rule PythonRule5 = CreateAstRule(
             31,
             "python_rule_5",
             "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGNvbnN0IGVycm9yID0gYnVpbGRFcnJvcihtb2RlLnN0YXJ0LmxpbmUsIG1vZGUuc3RhcnQuY29sLCBtb2RlLmVuZC5saW5lLCBtb2RlLmVuZC5jb2wsICJlcnJvciBtZXNzYWdlIiwgIkNSSVRJQ0FMIiwgInNlY3VyaXR5Iik7CiAgICBhZGRFcnJvcihlcnJvcik7CiAgfQp9",
-        "Python");
+            "Python");
 
         public static readonly Rule JavaRule1 = CreateAstRule(
             20L,
@@ -65,8 +66,8 @@ namespace Tests.Rosie
                 case "multipleRulesetsSingleLanguage":
                     return MultipleRulesetsSingleLanguage(); //Python
                 case "multipleRulesetsMultipleLanguages":
-                return MultipleRulesetsMultipleLanguages(); //Python, Java
-                    case "erroredRuleset":
+                    return MultipleRulesetsMultipleLanguages(); //Python, Java
+                case "erroredRuleset":
                     return null;
                 default:
                     return ImmutableList.Create<RuleSetsForClient>();
@@ -92,7 +93,7 @@ namespace Tests.Rosie
         private static IReadOnlyCollection<RuleSetsForClient> SingleRulesetSingleLanguage()
         {
             var rules = new List<Rule> { PythonRule1, PythonRule2, PythonRule3 };
-            var ruleset = new RuleSetsForClient(1234, "python-ruleset", rules);
+            var ruleset = new RuleSetsForClient { Id = 1234, Name = "python-ruleset", Rules = rules };
             return ImmutableList.Create(ruleset);
         }
 
@@ -102,7 +103,10 @@ namespace Tests.Rosie
         public static IReadOnlyCollection<RuleSetsForClient> SingleRulesetMultipleLanguages()
         {
             var rules = new List<Rule> { PythonRule1, JavaRule1, PythonRule3 };
-            var ruleset = new RuleSetsForClient(2345, "mixed-ruleset", rules);
+            var ruleset = new RuleSetsForClient
+            {
+                Id = 2345, Name = "mixed-ruleset", Rules = rules
+            };
             return ImmutableList.Create(ruleset);
         }
 
@@ -114,21 +118,22 @@ namespace Tests.Rosie
             var rules = new List<Rule> { PythonRule1, PythonRule2 };
             var rules2 = new List<Rule> { PythonRule3 };
 
-            var ruleset = new RuleSetsForClient(1234, "python-ruleset", rules);
-            var ruleset2 = new RuleSetsForClient(6789, "python-ruleset-2", rules2);
+            var ruleset = new RuleSetsForClient { Id = 1234, Name = "python-ruleset", Rules = rules };
+            var ruleset2 = new RuleSetsForClient { Id = 6789, Name = "python-ruleset-2", Rules = rules2 };
 
             return ImmutableList.Create(ruleset, ruleset2);
         }
-        
+
         /// <summary>
         /// Returns multiple rulesets with rules configured for different languages.
         /// </summary>
-        public static IReadOnlyCollection<RuleSetsForClient> MultipleRulesetsMultipleLanguages() {
+        private static IReadOnlyCollection<RuleSetsForClient> MultipleRulesetsMultipleLanguages()
+        {
             var rules = new List<Rule> { PythonRule4, JavaRule1 };
             var rules2 = new List<Rule> { PythonRule5 };
 
-            var ruleset = new RuleSetsForClient(5678, "mixed-ruleset", rules);
-            var ruleset2 = new RuleSetsForClient(6789, "python-ruleset", rules2);
+            var ruleset = new RuleSetsForClient { Id = 5678, Name = "mixed-ruleset", Rules = rules };
+            var ruleset2 = new RuleSetsForClient { Id = 6789, Name = "python-ruleset", Rules = rules2 };
 
             return ImmutableList.Create(ruleset, ruleset2);
         }

--- a/src/Tests/Rosie/RulesetsForClientTestSupport.cs
+++ b/src/Tests/Rosie/RulesetsForClientTestSupport.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GraphQLClient.Model.Rosie;
+
+namespace Tests.Rosie
+{
+    /// <summary>
+    /// Test utility for creating <see cref="RuleSetsForClient"/>s.
+    /// </summary>
+    public static class RulesetsForClientTestSupport
+    {
+        public static readonly Rule PythonRule1 = CreateAstRule(
+            10L,
+            "python_rule_1",
+            "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKfQ==",
+            "Python");
+
+        public static readonly Rule PythonRule2 = CreateAstRule(
+            11L,
+            "python_rule_2",
+            "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGFkZEVycm9yKGJ1aWxkRXJyb3IobW9kZS5zdGFydC5saW5lLCBtb2RlLnN0YXJ0LmNvbCwgbW9kZS5lbmQubGluZSwgbW9kZS5lbmQuY29sLCAiZXJyb3IgbWVzc2FnZSIsICJDUklUSUNBTCIsICJzZWN1cml0eSIpKTsKICB9Cn0=",
+            "Python");
+
+        public static readonly Rule PythonRule3 = CreateAstRule(
+            12L,
+            "python_rule_3",
+            "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGNvbnN0IGVycm9yID0gYnVpbGRFcnJvcihtb2RlLnN0YXJ0LmxpbmUsIG1vZGUuc3RhcnQuY29sLCBtb2RlLmVuZC5saW5lLCBtb2RlLmVuZC5jb2wsICJlcnJvciBtZXNzYWdlIiwgIkNSSVRJQ0FMIiwgInNlY3VyaXR5Iik7CiAgICBhZGRFcnJvcihlcnJvcik7CiAgfQp9",
+            "Python");
+
+        private static readonly Rule JavaRule1 = CreateAstRule(
+            20L,
+            "java_rule_1",
+            "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGFkZEVycm9yKGJ1aWxkRXJyb3IobW9kZS5zdGFydC5saW5lLCBtb2RlLnN0YXJ0LmNvbCwgbW9kZS5lbmQubGluZSwgbW9kZS5lbmQuY29sLCAiZXJyb3IgbWVzc2FnZSIsICJDUklUSUNBTCIsICJzZWN1cml0eSIpKTsKICB9Cn0=",
+            "Java");
+
+        /// <summary>
+        /// Returns test rulesets based on the argument ruleset names. Currently, rulesets are returned based on the first
+        /// value in the provided list.
+        /// </summary>
+        public static IReadOnlyCollection<RuleSetsForClient>? GetRulesetsForClient(
+            IReadOnlyCollection<string> rulesetNames)
+        {
+            if (rulesetNames.Count == 0)
+                return ImmutableList.Create<RuleSetsForClient>();
+
+            switch (rulesetNames.ToList()[0])
+            {
+                case "singleRulesetSingleLanguage":
+                    return SingleRulesetSingleLanguage(); //Python
+                // case "singleRulesetMultipleLanguagesDefaultTimestamp":
+                case "singleRulesetMultipleLanguages":
+                    return SingleRulesetMultipleLanguages(); //Python, Java
+                case "multipleRulesetsSingleLanguage":
+                    return MultipleRulesetsSingleLanguage(); //Python
+                // case "multipleRulesetsMultipleLanguages":
+                //     return MultipleRulesetsMultipleLanguages(); //Python, Java
+                // case "erroredRuleset":
+                //     return null;
+                default:
+                    return ImmutableList.Create<RuleSetsForClient>();
+            }
+        }
+
+        public static long GetRulesetsLastTimestamp(IReadOnlyCollection<string> rulesetNames)
+        {
+            return rulesetNames.ToList()[0] switch
+            {
+                "singleRulesetSingleLanguage" => 101L,
+                "singleRulesetMultipleLanguagesDefaultTimestamp" => 100L,
+                "singleRulesetMultipleLanguages" => 102L,
+                "multipleRulesetsSingleLanguage" => 103L,
+                "multipleRulesetsMultipleLanguages" => 104L,
+                _ => -1L
+                // _ => null
+            };
+        }
+
+        /// <summary>
+        /// Returns a single ruleset with a few rules, all configured for the same language.
+        /// </summary>
+        private static IReadOnlyCollection<RuleSetsForClient> SingleRulesetSingleLanguage()
+        {
+            var rules = new List<Rule> { PythonRule1, PythonRule2, PythonRule3 };
+            var ruleset = new RuleSetsForClient(1234, "python-ruleset", rules);
+            return ImmutableList.Create(ruleset);
+        }
+
+        /// <summary>
+        /// Returns a single ruleset with a few rules configured for different languages.
+        /// </summary>
+        public static IReadOnlyCollection<RuleSetsForClient> SingleRulesetMultipleLanguages()
+        {
+            var rules = new List<Rule> { PythonRule1, JavaRule1, PythonRule3 };
+            var ruleset = new RuleSetsForClient(2345, "mixed-ruleset", rules);
+            return ImmutableList.Create(ruleset);
+        }
+
+        /// <summary>
+        /// Returns multiple rulesets with rules all configured for the same language.
+        /// </summary>
+        private static IReadOnlyCollection<RuleSetsForClient> MultipleRulesetsSingleLanguage()
+        {
+            var rules = new List<Rule> { PythonRule1, PythonRule2 };
+            var rules2 = new List<Rule> { PythonRule3 };
+
+            var ruleset = new RuleSetsForClient(1234, "python-ruleset", rules);
+            var ruleset2 = new RuleSetsForClient(6789, "python-ruleset-2", rules2);
+
+            return ImmutableList.Create(ruleset, ruleset2);
+        }
+
+        private static Rule CreateAstRule(long id, string name, string content, string language)
+        {
+            return new Rule
+            {
+                Id = id,
+                Name = name,
+                Content = content,
+                RuleType = "Ast",
+                Language = language,
+                Pattern = null,
+                ElementChecked = null
+            };
+        }
+    }
+}

--- a/src/Tests/TestCodigaClient.cs
+++ b/src/Tests/TestCodigaClient.cs
@@ -18,49 +18,49 @@ namespace Tests
         {
         }
 
-        public Task<GraphQLResponse<GetUserResult>> GetUserAsync()
+        public async Task<GraphQLResponse<GetUserResult>> GetUserAsync()
         {
-            return Task.FromResult<GraphQLResponse<GetUserResult>>(null);
+            return await Task.FromResult<GraphQLResponse<GetUserResult>>(null);
         }
 
-        public Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientByShortcutAsync(string language)
+        public async Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientByShortcutAsync(string language)
         {
-            return Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
+            return await Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
         }
 
-        public Task<long> GetRecipesForClientByShortcutLastTimestampAsync(string language)
+        public async Task<long> GetRecipesForClientByShortcutLastTimestampAsync(string language)
         {
-            return Task.FromResult(-1L);
+            return await Task.FromResult(-1L);
         }
 
-        public Task<string> RecordRecipeUseAsync(long recipeId)
+        public async Task<string> RecordRecipeUseAsync(long recipeId)
         {
-            return Task.FromResult<string>(null);
+            return await Task.FromResult<string>(null);
         }
 
-        public Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientSemanticAsync(string keywords,
+        public async Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientSemanticAsync(string keywords,
             IReadOnlyCollection<string> languages, bool onlyPublic, int howMany,
             int skip)
         {
-            return Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
+            return await Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
         }
 
-        public Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientSemanticAsync(string keywords,
+        public async Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientSemanticAsync(string keywords,
             IReadOnlyCollection<string> languages, bool onlyPublic, bool onlyPrivate,
             bool onlySubscribed, int howMany, int skip)
         {
-            return Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
+            return await Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
         }
 
-        public Task<IReadOnlyCollection<RuleSetsForClient>?> GetRulesetsForClientAsync(
+        public async Task<IReadOnlyCollection<RuleSetsForClient>?> GetRulesetsForClientAsync(
             IReadOnlyCollection<string> names)
         {
-            return Task.FromResult(RulesetsForClientTestSupport.GetRulesetsForClient(names));
+            return await Task.FromResult(RulesetsForClientTestSupport.GetRulesetsForClient(names));
         }
 
-        public Task<long> GetRulesetsLastUpdatedTimestampAsync(IReadOnlyCollection<string> names)
+        public async Task<long> GetRulesetsLastUpdatedTimestampAsync(IReadOnlyCollection<string> names)
         {
-            return Task.FromResult(RulesetsForClientTestSupport.GetRulesetsLastTimestamp(names));
+            return await Task.FromResult(RulesetsForClientTestSupport.GetRulesetsLastTimestamp(names));
         }
         
         public void Dispose()

--- a/src/Tests/TestCodigaClient.cs
+++ b/src/Tests/TestCodigaClient.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQLClient;
+using GraphQLClient.Model.Rosie;
+using Tests.Rosie;
+
+namespace Tests
+{
+    /// <summary>
+    /// Codiga client implementation for testing.
+    /// </summary>
+    public class TestCodigaClient : ICodigaClient
+    {
+        public string Fingerprint { get; }
+
+        public void SetApiToken(string apiToken)
+        {
+        }
+
+        public Task<GraphQLResponse<GetUserResult>> GetUserAsync()
+        {
+            return Task.FromResult<GraphQLResponse<GetUserResult>>(null);
+        }
+
+        public Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientByShortcutAsync(string language)
+        {
+            return Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
+        }
+
+        public Task<long> GetRecipesForClientByShortcutLastTimestampAsync(string language)
+        {
+            return Task.FromResult(-1L);
+        }
+
+        public Task<string> RecordRecipeUseAsync(long recipeId)
+        {
+            return Task.FromResult<string>(null);
+        }
+
+        public Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientSemanticAsync(string keywords,
+            IReadOnlyCollection<string> languages, bool onlyPublic, int howMany,
+            int skip)
+        {
+            return Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
+        }
+
+        public Task<IReadOnlyCollection<CodigaSnippet>?> GetRecipesForClientSemanticAsync(string keywords,
+            IReadOnlyCollection<string> languages, bool onlyPublic, bool onlyPrivate,
+            bool onlySubscribed, int howMany, int skip)
+        {
+            return Task.FromResult<IReadOnlyCollection<CodigaSnippet>?>(null);
+        }
+
+        public Task<IReadOnlyCollection<RuleSetsForClient>?> GetRulesetsForClientAsync(
+            IReadOnlyCollection<string> names)
+        {
+            return Task.FromResult(RulesetsForClientTestSupport.GetRulesetsForClient(names));
+        }
+
+        public Task<long> GetRulesetsLastUpdatedTimestampAsync(IReadOnlyCollection<string> names)
+        {
+            return Task.FromResult(RulesetsForClientTestSupport.GetRulesetsLastTimestamp(names));
+        }
+        
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Tests/TestCodigaClientProvider.cs
+++ b/src/Tests/TestCodigaClientProvider.cs
@@ -1,0 +1,22 @@
+using Extension.Caching;
+using GraphQLClient;
+
+namespace Tests
+{
+    /// <summary>
+    /// Codiga client provider implementation for testing.
+    /// </summary>
+    public class TestCodigaClientProvider : ICodigaClientProvider
+    {
+        public bool TryGetClient(out ICodigaClient client)
+        {
+            client = GetClient();
+            return true;
+        }
+
+        public ICodigaClient GetClient()
+        {
+            return new TestCodigaClient();
+        }
+    }
+}


### PR DESCRIPTION
### Changes
- `RosieHighlightActionsSourceProvider`
  - Empty spans are no longer filtered out, so that the lightbulb actions are displayed when mouse-hovering over a violation, and not just via Ctrl+./Alt+Enter keyboard shortcuts.
- The tagging now gets updated in an editor getting focus when tagging hasn't been updated there for the latest state of the rules cache.
  - See `RosieViolationTagger` and `RosieViolationTaggerProvider`.
- The tagging gets updated in the currently active and in-focus editor when the rules cache is updated:
  - See `RosieRulesCache.NotifyActiveDocumentForTagUpdateAsync()`.
- Did some minor code optimizations and renaming.
- Implemented unit tests for:
  - `RosieRulesCache`
  - `RosieUtils`
  - `CodigaConfigFileUtil`