### PR TITLE
Add VS version number user-agent to the GraphQL client.

### DIFF
--- a/src/GraphQLClient/GraphQLClient.csproj
+++ b/src/GraphQLClient/GraphQLClient.csproj
@@ -7,9 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.475" />
     <PackageReference Include="GraphQL.Client" Version="5.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="5.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.3.32804.24" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="17.3.32804.24" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Changes
- `CodigaClient`
  - Added `VisualStudio/<version number>` user agent header to the GraphQL client.
  - If the version number if not available, then the user agent is simply `VisualStudio`.