### PR TITLE
Rosie tests and fixes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -135,6 +135,7 @@ at [Implementing an IDE plugin for analyzing custom rules](https://doc.codiga.io
 In order to perform code analysis, users must have a `codiga.yml` file in their Solution's root directory,
 with at least one valid ruleset name. If there is no ruleset name, or no valid ruleset name defined, then code analysis
 will not be performed.
+If what is opened is simply a folder, and not an actual solution, the `codiga.yml` file is still recognized in there.
 
 [`CodigaConfigFileUtil`](/src/Extension/Rosie/CodigaConfigFileUtil.cs) is responsible for finding this config file in the Solution root, and for parsing this config file into a
 [`CodigaCodeAnalysisConfig`](/src/Extension/Rosie/CodigaCodeAnalysisConfig.cs) containing the list of ruleset names.

--- a/src/Extension/Extension.csproj
+++ b/src/Extension/Extension.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Rosie\RosieRulesCacheValue.cs" />
     <Compile Include="Rosie\RosieSeverities.cs" />
     <Compile Include="Rosie\RosieUtils.cs" />
+    <Compile Include="Rosie\TextBufferDataProvider.cs" />
     <Compile Include="SnippetSearch\Preview\PreviewClassifier.cs" />
     <Compile Include="SnippetSearch\Preview\PreviewClassifierFormat.cs" />
     <Compile Include="SnippetSearch\Preview\PreviewClassifierProvider.cs" />

--- a/src/Extension/Rosie/Annotation/ApplyRosieFixSuggestedAction.cs
+++ b/src/Extension/Rosie/Annotation/ApplyRosieFixSuggestedAction.cs
@@ -62,12 +62,15 @@ namespace Extension.Rosie.Annotation
         /// If the start offset for additions, or the start/end offset for removals and updates, received from the rule configuration,
         /// is either null or is outside the current file's range, we don't apply the fix.
         /// </summary>
-        internal bool HasInvalidEditOffset()
+        private bool HasInvalidEditOffset()
         {
             var hasInvalidOffset = true;
             try
             {
-                var documentLastPosition = _textBuffer.CurrentSnapshot.Length - 1;
+                var documentLastPosition =
+                    _textBuffer.CurrentSnapshot.Length == 0
+                        ? 0
+                        : _textBuffer.CurrentSnapshot.Length - 1;
                 hasInvalidOffset = _edits
                     .Any(edit =>
                     {

--- a/src/Extension/Rosie/Annotation/OpenOnCodigaHubSuggestedAction.cs
+++ b/src/Extension/Rosie/Annotation/OpenOnCodigaHubSuggestedAction.cs
@@ -32,12 +32,17 @@ namespace Extension.Rosie.Annotation
         {
             try
             {
-                Process.Start($"https://app.codiga.io/hub/ruleset/{_annotation.RulesetName}/{_annotation.RuleName}");
+                Process.Start(GetUrlString());
             }
             catch
             {
                 // ignored
             }
+        }
+
+        internal string GetUrlString()
+        {
+            return $"https://app.codiga.io/hub/ruleset/{_annotation.RulesetName}/{_annotation.RuleName}";
         }
 
         #region Action sets and preview

--- a/src/Extension/Rosie/Annotation/RosieViolationSquiggleTagger.cs
+++ b/src/Extension/Rosie/Annotation/RosieViolationSquiggleTagger.cs
@@ -129,6 +129,12 @@ namespace Extension.Rosie.Annotation
 
         private bool _isDisposed;
 
+        //For testing
+        public RosieViolationSquiggleTagger(ITagAggregator<RosieViolationTag> rosieViolationAggregator)
+        {
+            _rosieViolationAggregator = rosieViolationAggregator;
+        }
+        
         public RosieViolationSquiggleTagger(ITextBuffer sourceBuffer,
             ITagAggregator<RosieViolationTag> rosieViolationAggregator)
         {
@@ -166,14 +172,11 @@ namespace Extension.Rosie.Annotation
             {
                 var spanCollection = violationTagSpan.Span.GetSpans(snapshot);
                 if (spanCollection.Count == 1)
-                {
-                    var errorSpan = spanCollection[0];
                     yield return new TagSpan<IErrorTag>(
-                        errorSpan,
+                        /*errorSpan*/ spanCollection[0],
                         new RosieViolationSquiggleTag(
                             GetSquiggleTypeForRosieSeverity(violationTagSpan.Tag.Annotation.Severity),
                             violationTagSpan.Tag.Annotation.Message));
-                }
             }
         }
 

--- a/src/Extension/Rosie/Annotation/RosieViolationTagger.cs
+++ b/src/Extension/Rosie/Annotation/RosieViolationTagger.cs
@@ -204,7 +204,9 @@ namespace Extension.Rosie.Annotation
                 //span:             |--------|
                 //anno:                          |--------|
                 //anno: |--------|
-                if (annotationStart > span.End.Position || annotationEnd < span.Start.Position)
+                if (annotationStart > span.End.Position
+                    || annotationEnd < span.Start.Position
+                    || annotationStart > annotationEnd)
                     continue;
 
                 if (annotationStart <= span.Start.Position)

--- a/src/Extension/Rosie/Annotation/RosieViolationTaggerProvider.cs
+++ b/src/Extension/Rosie/Annotation/RosieViolationTaggerProvider.cs
@@ -17,7 +17,6 @@ namespace Extension.Rosie.Annotation
     //Restricts the creation of this provider to certain text view roles
     [TextViewRole(PredefinedTextViewRoles.Document)]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
-    // [TextViewRole(PredefinedTextViewRoles.Analyzable)]
     [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
     internal class RosieViolationTaggerProvider : IViewTaggerProvider
     {

--- a/src/Extension/Rosie/CodigaConfigFileUtil.cs
+++ b/src/Extension/Rosie/CodigaConfigFileUtil.cs
@@ -2,9 +2,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
-using Solution = EnvDTE.Solution;
 
 namespace Extension.Rosie
 {
@@ -34,13 +35,21 @@ namespace Extension.Rosie
         private const string CodigaConfigFileName = "codiga.yml";
 
         /// <summary>
-        /// Looks up the Codiga config file in the provided Solution's root directory.
+        /// Looks up the Codiga config file in the provided Solution's root directory,
+        /// or in the currently open folder.
+        /// <br/>
+        /// See https://stackoverflow.com/questions/49278306/how-do-i-find-the-open-folder-in-a-vsix-extension
         /// </summary>
-        /// <param name="solution">The current solution to find the config file in</param>
+        /// <param name="serviceProvider">The service provider to retrieve information about the solution from.</param>
         /// <returns>The path of the config file, or null if it doesn't exist.</returns>
-        public static string? FindCodigaConfigFile(Solution solution)
+        public static string? FindCodigaConfigFile(SVsServiceProvider serviceProvider)
         {
-            var solutionRoot = Path.GetDirectoryName(solution.FullName);
+            var sol = (IVsSolution)serviceProvider.GetService(typeof(SVsSolution));
+
+            // 'dir' contains the solution's directory path, or the open folder's path when it is a folder that's open, and not a solution
+            sol.GetSolutionInfo(out var dir, out var file, out var ops);
+
+            var solutionRoot = Path.GetDirectoryName(dir);
             if (solutionRoot == null)
                 return null;
 

--- a/src/Extension/Rosie/Model/RosieAnnotation.cs
+++ b/src/Extension/Rosie/Model/RosieAnnotation.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Extension.Rosie.Model
 {
@@ -28,6 +29,33 @@ namespace Extension.Rosie.Model
             Start = violation.Start;
             End = violation.End;
             Fixes = violation.Fixes;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RosieAnnotation annotation &&
+                   RulesetName == annotation.RulesetName &&
+                   RuleName == annotation.RuleName &&
+                   Message == annotation.Message &&
+                   Severity == annotation.Severity &&
+                   Category == annotation.Category &&
+                   EqualityComparer<RosiePosition>.Default.Equals(Start, annotation.Start) &&
+                   EqualityComparer<RosiePosition>.Default.Equals(End, annotation.End) &&
+                   Fixes.SequenceEqual(annotation.Fixes);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 638126934;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(RulesetName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(RuleName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Severity);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Category);
+            hashCode = hashCode * -1521134295 + EqualityComparer<RosiePosition>.Default.GetHashCode(Start);
+            hashCode = hashCode * -1521134295 + EqualityComparer<RosiePosition>.Default.GetHashCode(End);
+            hashCode = hashCode * -1521134295 + EqualityComparer<IList<RosieViolationFix>>.Default.GetHashCode(Fixes);
+            return hashCode;
         }
     }
 }

--- a/src/Extension/Rosie/Model/RosiePosition.cs
+++ b/src/Extension/Rosie/Model/RosiePosition.cs
@@ -28,7 +28,7 @@ namespace Extension.Rosie.Model
         /// It doesn't adjust the offset if it is 0, so at the beginning of a line. 
         /// </summary>
         /// <param name="offset">the offset to adjust</param>
-        private int AdjustOffset(int offset)
+        private static int AdjustOffset(int offset)
         {
             return offset != 0 ? offset - 1 : offset;
         }

--- a/src/Extension/Rosie/Model/RosieViolationFixEdit.cs
+++ b/src/Extension/Rosie/Model/RosieViolationFixEdit.cs
@@ -10,12 +10,12 @@ namespace Extension.Rosie.Model
         /// <summary>
         /// The position of the edit from where the fix will begin.
         /// </summary>
-        public RosiePosition Start { get; set; }
+        public RosiePosition? Start { get; set; }
 
         /// <summary>
         /// The position of the edit at where the fix will end.
         /// </summary>
-        public RosiePosition End { get; set; }
+        public RosiePosition? End { get; set; }
 
         /// <summary>
         /// Content for string insertion and replacement in the editor. Not used for removal edits.

--- a/src/Extension/Rosie/RosieRulesCache.cs
+++ b/src/Extension/Rosie/RosieRulesCache.cs
@@ -15,7 +15,6 @@ using Extension.SnippetFormats;
 using GraphQLClient;
 using GraphQLClient.Model.Rosie;
 using Microsoft.VisualStudio.Shell;
-using Solution = EnvDTE.Solution;
 
 namespace Extension.Rosie
 {
@@ -75,7 +74,12 @@ namespace Extension.Rosie
         
         public static RosieRulesCache? Instance { get; set; }
 
-        private Solution? _solution;
+        /// <summary>
+        /// Used to retrieve information about the solution, or the open directory,
+        /// in <see cref="CodigaConfigFileUtil"/>.
+        /// Null only in case of testing.
+        /// </summary>
+        private SVsServiceProvider? _serviceProvider;
 
         private RosieRulesCache()
         {
@@ -85,9 +89,8 @@ namespace Extension.Rosie
         }
         
         //For testing
-        private RosieRulesCache(Solution solution, ICodigaClientProvider clientProvider)
+        private RosieRulesCache(ICodigaClientProvider clientProvider)
         {
-            _solution = solution;
             _clientProvider = clientProvider;
             _cachedRules = new ConcurrentDictionary<LanguageUtils.LanguageEnumeration, RosieRulesCacheValue>();
             RulesetNames = new SynchronizedCollection<string>();
@@ -100,9 +103,9 @@ namespace Extension.Rosie
         }
         
         //For testing
-        public static void Initialize(Solution solution, ICodigaClientProvider clientProvider)
+        public static void Initialize(SVsServiceProvider? serviceProvider, ICodigaClientProvider clientProvider)
         {
-            Instance = new RosieRulesCache(solution, clientProvider);
+            Instance = new RosieRulesCache(clientProvider) { _serviceProvider = serviceProvider };
         }
 
         #region Polling and update
@@ -118,9 +121,9 @@ namespace Extension.Rosie
 
             //Retrieve the DTE object from which the Solution can be accessed
             ThreadHelper.ThrowIfNotOnUIThread();
-            var vssp = VS.GetMefService<SVsServiceProvider>();
-            _dte = (_DTE)vssp.GetService(typeof(_DTE));
-            
+            _serviceProvider = VS.GetMefService<SVsServiceProvider>();
+            _dte = (_DTE)_serviceProvider.GetService(typeof(_DTE));
+
             PollRulesetsAsync(_cancellationTokenSource.Token);
         }
 
@@ -169,8 +172,7 @@ namespace Extension.Rosie
             if (!_clientProvider.TryGetClient(out var client))
                 return UpdateResult.NoCodigaClient;
 
-            _solution ??= _dte.Solution;
-            var codigaConfigFile = CodigaConfigFileUtil.FindCodigaConfigFile(_solution);
+            var codigaConfigFile = CodigaConfigFileUtil.FindCodigaConfigFile(_serviceProvider);
 
             if (codigaConfigFile == null || !File.Exists(codigaConfigFile))
             {

--- a/src/Extension/Rosie/RosieRulesCache.cs
+++ b/src/Extension/Rosie/RosieRulesCache.cs
@@ -96,10 +96,11 @@ namespace Extension.Rosie
             RulesetNames = new SynchronizedCollection<string>();
         }
 
-        public static void Initialize()
+        public static void Initialize(bool startPolling = true)
         {
             Instance = new RosieRulesCache();
-            Instance.StartPolling();
+            if (startPolling)
+                Instance.StartPolling();
         }
         
         //For testing
@@ -164,7 +165,9 @@ namespace Extension.Rosie
 
         public enum UpdateResult
         {
-            NoCodigaClient, NoConfigFile, Success 
+            NoCodigaClient,
+            NoConfigFile,
+            Success
         }
 
         public async Task<UpdateResult> HandleCacheUpdateAsync()
@@ -391,6 +394,7 @@ namespace Extension.Rosie
         {
             Instance?._cancellationTokenSource?.Cancel();
             Instance?.ClearCache();
+            IsInitializedWithRules = false;
             Instance = null;
         }
 

--- a/src/Extension/Rosie/RosieSeverities.cs
+++ b/src/Extension/Rosie/RosieSeverities.cs
@@ -5,7 +5,7 @@ namespace Extension.Rosie
     /// <br/>
     /// See <c>ruleResponses.violations.severity</c> property on https://doc.codiga.io/docs/rosie/ide-specification/#getting-the-results.
     /// </summary>
-    internal static class RosieSeverities
+    public static class RosieSeverities
     {
         public const string Critical = "critical";
         public const string Error = "error";

--- a/src/Extension/Rosie/TextBufferDataProvider.cs
+++ b/src/Extension/Rosie/TextBufferDataProvider.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Extension.Rosie
+{
+    /// <summary>
+    /// Provides a way to 'mock' the behaviour of an <see cref="ITextBuffer"/> and the response from Codiga.
+    /// <br/>
+    /// <c>ITextBuffer.GetFileName()</c> must be called on the main/UI thread, but
+    /// in case of unit testing, there is no such thing, thus bypassing it with this class.
+    /// </summary>
+    public class TextBufferDataProvider
+    {
+        public Func<ITextBuffer, string?> FileName { get; set; } = buffer => buffer.GetFileName();
+
+        public Func<ITextBuffer, string> FileText { get; set; } = buffer => buffer.CurrentSnapshot.GetText();
+
+        /// <summary>
+        /// To limit code execution when something is not achievable, or unnecessary to call during unit testing.  
+        /// </summary>
+        public bool IsTestMode { get; set; }
+    }
+}

--- a/src/Tests/Rosie/Annotation/ApplyRosieFixSuggestedActionTest.cs
+++ b/src/Tests/Rosie/Annotation/ApplyRosieFixSuggestedActionTest.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Extension.Rosie.Annotation;
+using Extension.Rosie.Model;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using NUnit.Framework;
+using static Tests.TextBufferMockSupport;
+
+namespace Tests.Rosie.Annotation
+{
+    /// <summary>
+    /// Unit test for <see cref="ApplyRosieFixSuggestedAction"/>.
+    /// </summary>
+    [TestFixture]
+    public class ApplyRosieFixSuggestedActionTest
+    {
+        #region Display text
+
+        [Test]
+        public void DisplayText_should_return_display_text()
+        {
+            var fix = new RosieViolationFix { Description = "Apply this change" };
+            var applyFix = new ApplyRosieFixSuggestedAction(new Mock<ITextBuffer>().Object, fix);
+
+            Assert.That(applyFix.DisplayText, Is.EqualTo("Fix: Apply this change"));
+        }
+
+        #endregion
+
+        #region HasInvalidEditOffset
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_add_fix_when_edit_start_position_is_null()
+        {
+            var textBuffer = MockTextBuffer("some content", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    new RosieViolationFixEdit { EditType = "add", Start = null, },
+                    new RosieViolationFixEdit { EditType = "add", Start = new RosiePosition { Line = 1, Col = 0 } }
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("some content"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_add_fix_when_edit_start_is_less_than_zero()
+        {
+            var textBuffer = MockTextBuffer("some content", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    new RosieViolationFixEdit { EditType = "add", Start = new RosiePosition { Line = 1, Col = -10 } },
+                    new RosieViolationFixEdit { EditType = "add", Start = new RosiePosition { Line = 1, Col = 0 } }
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("some content"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_add_fix_when_edit_start_is_greater_than_document_end()
+        {
+            var textBuffer = MockTextBuffer("some content", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    new RosieViolationFixEdit { EditType = "add", Start = new RosiePosition { Line = 1, Col = 60 } },
+                    new RosieViolationFixEdit { EditType = "add", Start = new RosiePosition { Line = 1, Col = 0 } }
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("some content"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_edit_start_is_null()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    new RosieViolationFixEdit
+                    {
+                        EditType = "remove",
+                        Start = null,
+                        End = new RosiePosition { Line = 1, Col = 7 }
+                    }
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_edit_end_is_null()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    CreateEdit("remove", 1, 0, 1, 7),
+                    new RosieViolationFixEdit
+                    {
+                        EditType = "remove",
+                        Start = new RosiePosition { Line = 1, Col = 0 },
+                        End = null
+                    }
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_edit_start_is_less_than_zero()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("remove", 1, -10, 1, 7) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_edit_end_is_less_than_zero()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("remove", 1, 0, 1, -10) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_edit_start_is_greater_than_document_end()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("remove", 1, 40, 1, 7) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_edit_end_is_greater_than_document_end()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("remove", 1, 0, 1, 40) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+
+        [Test]
+        public void HasInvalidEditOffset_should_not_apply_fix_when_line_is_out_of_range()
+        {
+            var bufferContent = new TextBufferContent("some content");
+            var textSnapshot = MockTextSnapshot(out var textBuffer, bufferContent);
+            textSnapshot
+                .Setup(tss => tss.GetLineFromLineNumber(It.IsAny<int>()))
+                .Throws<IndexOutOfRangeException>();
+
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("add", 1, 5, 1, 10) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("some content"));
+        }
+
+        #endregion
+
+        #region Invoke
+
+        [Test]
+        public void Invoke_should_not_apply_fix_when_there_is_no_fix_edit_available()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>()
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("content-to-remove"));
+        }
+        
+        [Test]
+        public void Invoke_should_not_apply_edits_with_unknown_edit_types()
+        {
+            var textBuffer = MockTextBuffer("content-to-modify", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    CreateEdit("remove", 1, 0, 1, 10),
+                    CreateEdit("unknown", 1, 0, 1, 10, "inserted")
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("o-modify"));
+        }
+
+        [Test]
+        public void Invoke_should_insert_text()
+        {
+            var textBuffer = MockTextBuffer("content-to-insert_into", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("add", 1, 5, 1, 10, "added_text") }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("contadded_textent-to-insert_into"));
+        }
+
+        [Test]
+        public void Invoke_should_update_text()
+        {
+            var textBuffer = MockTextBuffer("content-to-update", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("update", 1, 0, 1, 10, "replacement_text") }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("replacement_texto-update"));
+        }
+
+        [Test]
+        public void Invoke_should_remove_text()
+        {
+            var textBuffer = MockTextBuffer("content-to-remove", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("remove", 1, 0, 1, 10) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("o-remove"));
+        }
+
+        [Test]
+        public void Invoke_should_apply_multiple_edits()
+        {
+            var textBuffer = MockTextBuffer("content-to-modify", out var bufferContent);
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    CreateEdit("remove", 1, 0, 1, 10),
+                    CreateEdit("add", 1, 0, 1, 10, "inserted")
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo("insertedo-modify"));
+        }
+
+        [Test]
+        public void Invoke_should_apply_update_text_in_multiple_lines_with_single_line_replacement()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("update", 2, 6, 3, 3, "replacement") }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"first-row
+seconreplacementird-row"));
+        }
+
+        [Test]
+        public void Invoke_should_apply_update_text_in_multiple_lines_with_multi_line_replacement()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit>
+                {
+                    CreateEdit("update", 2, 6, 3, 3, @"replacement
+text")
+                }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"first-row
+seconreplacement
+textird-row"));
+        }
+
+        [Test]
+        public void Invoke_should_apply_remove_text_in_multiple_lines()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var fix = new RosieViolationFix
+            {
+                Description = "Apply this change",
+                Edits = new List<RosieViolationFixEdit> { CreateEdit("remove", 2, 6, 3, 3) }
+            };
+
+            new ApplyRosieFixSuggestedAction(textBuffer.Object, fix).Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"first-row
+seconird-row"));
+        }
+
+        #endregion
+
+        #region Mock and test object creation
+
+        /// <summary>
+        /// Creates a <c>RosieViolationFixEdit</c> with the provided data.
+        /// </summary>
+        private static RosieViolationFixEdit CreateEdit(string editType, int startLine, int startCol, int endLine,
+            int endCol,
+            string? content = null)
+        {
+            var edit = new RosieViolationFixEdit
+            {
+                EditType = editType,
+                Start = new RosiePosition { Line = startLine, Col = startCol },
+                End = new RosiePosition { Line = endLine, Col = endCol }
+            };
+
+            if (content != null)
+                edit.Content = content;
+
+            return edit;
+        }
+
+        #endregion
+    }
+}

--- a/src/Tests/Rosie/Annotation/DisableRosieAnalysisSuggestedActionTest.cs
+++ b/src/Tests/Rosie/Annotation/DisableRosieAnalysisSuggestedActionTest.cs
@@ -1,0 +1,169 @@
+using System.Threading;
+using Extension.Rosie;
+using Extension.Rosie.Annotation;
+using Extension.Rosie.Model;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using NUnit.Framework;
+using static Tests.TextBufferMockSupport;
+
+namespace Tests.Rosie.Annotation
+{
+    /// <summary>
+    /// Unit test for <see cref="DisableRosieAnalysisSuggestedAction"/>.
+    /// </summary>
+    [TestFixture]
+    public class DisableRosieAnalysisSuggestedActionTest
+    {
+        [Test]
+        public void DisplayText_should_return_display_text()
+        {
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("This is the rule name", 0, 1, 2, 3),
+                new Mock<ITextBuffer>().Object);
+
+            Assert.That(action.DisplayText, Is.EqualTo("Remove error 'This is the rule name'"));
+        }
+
+        [Test]
+        public void Invoke_should_add_comment_when_invoked_on_annotation_from_document_start()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("rulename", 1, 0, 1, 3),
+                textBuffer.Object,
+                new TextBufferDataProvider { FileName = _ => "python_file.py", IsTestMode = true });
+
+            action.Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"# codiga-disable
+first-row
+second-row
+third-row"));
+        }
+
+        [Test]
+        public void Invoke_should_add_comment_when_invoked_in_first_line()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("rulename", 1, 5, 1, 8),
+                textBuffer.Object,
+                new TextBufferDataProvider { FileName = _ => "python_file.py", IsTestMode = true });
+
+            action.Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"# codiga-disable
+first-row
+second-row
+third-row"));
+        }
+
+        [Test]
+        public void Invoke_should_add_comment_when_invoked_on_annotation_from_line_end()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("rulename", 1, 11, 2, 0),
+                textBuffer.Object,
+                new TextBufferDataProvider { FileName = _ => "python_file.py", IsTestMode = true });
+
+            action.Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"# codiga-disable
+first-row
+second-row
+third-row"));
+        }
+
+        [Test]
+        public void Invoke_should_add_comment_when_invoked_in_not_first_not_last_line()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+  second-row
+third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("rulename", 2, 0, 2, 5),
+                textBuffer.Object,
+                new TextBufferDataProvider { FileName = _ => "python_file.py", IsTestMode = true });
+
+            action.Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"first-row
+  # codiga-disable
+  second-row
+third-row"));
+        }
+
+        [Test]
+        public void Invoke_should_add_comment_when_invoked_in_last_line()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+  second-row
+    third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("rulename", 3, 6, 3, 9),
+                textBuffer.Object,
+                new TextBufferDataProvider { FileName = _ => "python_file.py", IsTestMode = true });
+
+            action.Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"first-row
+  second-row
+    # codiga-disable
+    third-row"));
+        }
+
+        [Test]
+        public void Invoke_should_add_comment_when_invoked_on_annotation_from_document_end()
+        {
+            var bufferContent = new TextBufferContent(@"first-row
+  second-row
+    third-row");
+            MockTextSnapshot(out var textBuffer, bufferContent, true);
+
+            var action = new DisableRosieAnalysisSuggestedAction(
+                CreateRosieAnnotation("rulename", 3, 14, 3, 14),
+                textBuffer.Object,
+                new TextBufferDataProvider { FileName = _ => "python_file.py", IsTestMode = true });
+
+            action.Invoke(new CancellationToken());
+
+            Assert.That(bufferContent.Text, Is.EqualTo(@"first-row
+  second-row
+    # codiga-disable
+    third-row"));
+        }
+
+        /// <summary>
+        /// Creates a <c>RosieAnnotation</c> with the given rule name, and an underlying <c>RosieViolation</c>
+        /// with the provided start and end positions.
+        /// </summary>
+        private static RosieAnnotation CreateRosieAnnotation(string ruleName, int startLine, int startCol, int endLine,
+            int endCol)
+        {
+            return new RosieAnnotation(ruleName, "ruleset-name",
+                new RosieViolation
+                {
+                    Start = new RosiePosition { Line = startLine, Col = startCol },
+                    End = new RosiePosition { Line = endLine, Col = endCol }
+                });
+        }
+    }
+}

--- a/src/Tests/Rosie/Annotation/OpenOnCodigaHubSuggestedActionTest.cs
+++ b/src/Tests/Rosie/Annotation/OpenOnCodigaHubSuggestedActionTest.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Extension.Rosie.Annotation;
+using Extension.Rosie.Model;
+using NUnit.Framework;
+
+namespace Tests.Rosie.Annotation
+{
+    /// <summary>
+    /// Unit test for <see cref="OpenOnCodigaHubSuggestedAction"/>.
+    /// </summary>
+    [TestFixture]
+    public class OpenOnCodigaHubSuggestedActionTest
+    {
+        [Test]
+        public void GetUrlString_should_return_formatter_rule_page_url()
+        {
+            var rosieViolation = new RosieViolation
+            {
+                Message = "open_browser_fix",
+                Start = new RosiePosition { Line = 1, Col = 5 },
+                End = new RosiePosition { Line = 1, Col = 10 },
+                Severity = "INFORMATIONAL",
+                Category = "CODE_STYLE",
+                Fixes = new List<RosieViolationFix>()
+            };
+
+            var rosieAnnotation = new RosieAnnotation("rule-for-open-browser", "custom-ruleset-name", rosieViolation);
+
+            var urlString = new OpenOnCodigaHubSuggestedAction(rosieAnnotation).GetUrlString();
+
+            Assert.That(urlString,
+                Is.EqualTo("https://app.codiga.io/hub/ruleset/custom-ruleset-name/rule-for-open-browser"));
+        }
+    }
+}

--- a/src/Tests/Rosie/Annotation/RosieHighlightActionsSourceTest.cs
+++ b/src/Tests/Rosie/Annotation/RosieHighlightActionsSourceTest.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Extension.Rosie.Annotation;
+using Extension.Rosie.Model;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests.Rosie.Annotation
+{
+    /// <summary>
+    /// Unit test for <see cref="RosieHighlightActionsSource"/>.
+    /// </summary>
+    [TestFixture]
+    public class RosieHighlightActionsSourceTest
+    {
+        #region HasSuggestedActionsAsync
+
+        [Test]
+        public async Task HasSuggestedActionsAsync_should_return_false_when_provider_is_disposed()
+        {
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            actionsSource.Dispose();
+
+            var hasSuggestedAction = await actionsSource.HasSuggestedActionsAsync(
+                new Mock<ISuggestedActionCategorySet>().Object,
+                new SnapshotSpan(new Mock<ITextSnapshot>().Object, 0, 0),
+                new CancellationToken());
+
+            Assert.That(hasSuggestedAction, Is.EqualTo(false));
+        }
+
+        [Test]
+        public async Task HasSuggestedActionsAsync_should_return_false_when_no_aggregated_tag_is_returned()
+        {
+            var tagAggregator = MockTagAggregator(new List<IMappingTagSpan<RosieViolationTag>>());
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            var hasSuggestedAction = await actionsSource.HasSuggestedActionsAsync(
+                new Mock<ISuggestedActionCategorySet>().Object,
+                new SnapshotSpan(new Mock<ITextSnapshot>().Object, 0, 0),
+                new CancellationToken());
+
+            Assert.That(hasSuggestedAction, Is.EqualTo(false));
+        }
+
+        [Test]
+        public async Task HasSuggestedActionsAsync_should_return_true_when_at_least_one_aggregated_tag_is_returned()
+        {
+            var mappingSpan =
+                TaggingMockSupport.MockMappingSpan(new Mock<ITextSnapshot>(), new NormalizedSnapshotSpanCollection());
+            var tagAggregator = MockTagAggregator(new List<IMappingTagSpan<RosieViolationTag>>
+            {
+                CreateMappingTagSpan(mappingSpan, "rule", new List<RosieViolationFix>())
+            });
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            var hasSuggestedAction = await actionsSource.HasSuggestedActionsAsync(
+                new Mock<ISuggestedActionCategorySet>().Object,
+                new SnapshotSpan(new Mock<ITextSnapshot>().Object, 0, 0),
+                new CancellationToken());
+
+            Assert.That(hasSuggestedAction, Is.EqualTo(true));
+        }
+
+        #endregion
+
+        #region GetSuggestedActions
+
+        [Test]
+        public void GetSuggestedActions_should_return_no_suggestion_for_already_disposed_actions_source()
+        {
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            actionsSource.Dispose();
+
+            var hasSuggestedAction = GetSuggestedActions(actionsSource);
+
+            Assert.That(hasSuggestedAction, Is.Empty);
+        }
+
+        [Test]
+        public void GetSuggestedActions_should_return_no_suggestion_for_no_violation_in_range()
+        {
+            var tagAggregator = MockTagAggregator(new List<IMappingTagSpan<RosieViolationTag>>()); 
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            var suggestedActions = GetSuggestedActions(actionsSource);
+
+            Assert.That(suggestedActions, Is.Empty);
+        }
+
+        [Test]
+        public void GetSuggestedActions_should_return_only_disable_and_open_actions_for_no_violation_fix_available()
+        {
+            var mappingSpan =
+                TaggingMockSupport.MockMappingSpan(new Mock<ITextSnapshot>(), new NormalizedSnapshotSpanCollection());
+            var tagAggregator = MockTagAggregator(new List<IMappingTagSpan<RosieViolationTag>>
+            {
+                CreateMappingTagSpan(mappingSpan, "ruleWithNofix", new List<RosieViolationFix>())
+            });
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            var suggestedActions = GetSuggestedActions(actionsSource).ToList();
+
+            Assert.That(suggestedActions, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                var actions = suggestedActions[0].Actions.ToList();
+                Assert.That(actions, Has.Count.EqualTo(2));
+                Assert.That(actions[0], Is.InstanceOf<DisableRosieAnalysisSuggestedAction>());
+                Assert.That(actions[1], Is.InstanceOf<OpenOnCodigaHubSuggestedAction>());
+            });
+        }
+
+        [Test]
+        public void GetSuggestedActions_should_return_all_action_types()
+        {
+            var mappingSpan =
+                TaggingMockSupport.MockMappingSpan(new Mock<ITextSnapshot>(), new NormalizedSnapshotSpanCollection());
+            var tagAggregator = MockTagAggregator(new List<IMappingTagSpan<RosieViolationTag>>
+            {
+                CreateMappingTagSpan(mappingSpan, "ruleWithMultipleFixes",
+                    new List<RosieViolationFix> { new RosieViolationFix(), new RosieViolationFix() }),
+                CreateMappingTagSpan(mappingSpan, "ruleWithASingleFix",
+                    new List<RosieViolationFix> { new RosieViolationFix() }),
+            });
+            var actionsSource = new RosieHighlightActionsSource(tagAggregator.Object);
+
+            var suggestedActions = GetSuggestedActions(actionsSource).ToList();
+
+            Assert.That(suggestedActions, Has.Count.EqualTo(1));
+
+            var actions = suggestedActions[0].Actions.ToList();
+            Assert.That(actions, Has.Count.EqualTo(7));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actions[0], Is.InstanceOf<ApplyRosieFixSuggestedAction>());
+                Assert.That(actions[1], Is.InstanceOf<ApplyRosieFixSuggestedAction>());
+                Assert.That(actions[2], Is.InstanceOf<DisableRosieAnalysisSuggestedAction>());
+                Assert.That(actions[3], Is.InstanceOf<OpenOnCodigaHubSuggestedAction>());
+
+                Assert.That(actions[4], Is.InstanceOf<ApplyRosieFixSuggestedAction>());
+                Assert.That(actions[5], Is.InstanceOf<DisableRosieAnalysisSuggestedAction>());
+                Assert.That(actions[6], Is.InstanceOf<OpenOnCodigaHubSuggestedAction>());
+            });
+        }
+
+        #endregion
+
+        #region Mock and test object creation
+
+        /// <summary>
+        /// Creates a mock <c>ITagAggregator&lt;RosieViolationTag></c> whose <c>GetTags(SnapshotSpan)</c> method returns
+        /// the provided list of <c>IMappingTagSpan</c>s.
+        /// </summary>
+        private static Mock<ITagAggregator<RosieViolationTag>> MockTagAggregator(IEnumerable<IMappingTagSpan<RosieViolationTag>> mappingTagSpans)
+        {
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            tagAggregator
+                .Setup(a => a.GetTags(It.IsAny<SnapshotSpan>()))
+                .Returns(mappingTagSpans);
+            return tagAggregator;
+        }
+
+        /// <summary>
+        /// Mocks a single item returned by <c>ITagAggregator.GetTags(SnapshotSpan)</c>
+        /// with the argument fixes set for the underlying <c>RosieViolation</c>.
+        /// </summary>
+        private static MappingTagSpan<RosieViolationTag> CreateMappingTagSpan(IMock<IMappingSpan> mappingSpan,
+            string ruleName, IList<RosieViolationFix> fixes)
+        {
+            return new MappingTagSpan<RosieViolationTag>(
+                mappingSpan.Object,
+                new RosieViolationTag(
+                    new RosieAnnotation(ruleName, "ruleset-name",
+                        new RosieViolation { Fixes = fixes })));
+        }
+
+        /// <summary>
+        /// Calls <c>GetSuggestedActions()</c> on the argument <c>RosieHighlightActionsSource</c> with some mock argumets.
+        /// </summary>
+        private static IEnumerable<SuggestedActionSet> GetSuggestedActions(RosieHighlightActionsSource actionsSource)
+        {
+            return actionsSource.GetSuggestedActions(
+                new Mock<ISuggestedActionCategorySet>().Object,
+                new SnapshotSpan(new Mock<ITextSnapshot>().Object, 0, 0),
+                new CancellationToken());
+        }
+
+        #endregion
+    }
+}

--- a/src/Tests/Rosie/Annotation/RosieViolationSquiggleTaggerTest.cs
+++ b/src/Tests/Rosie/Annotation/RosieViolationSquiggleTaggerTest.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using System.Linq;
+using Extension.Rosie;
+using Extension.Rosie.Annotation;
+using Extension.Rosie.Model;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests.Rosie.Annotation
+{
+    /// <summary>
+    /// Unit test for <see cref="RosieViolationSquiggleTagger"/>.
+    /// </summary>
+    [TestFixture]
+    public class RosieViolationSquiggleTaggerTest
+    {
+        [Test]
+        public void GetTags_should_return_no_tag_for_no_span()
+        {
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            var tagger = new RosieViolationSquiggleTagger(tagAggregator.Object);
+            var spanCollection =
+                new NormalizedSnapshotSpanCollection(new Mock<ITextSnapshot>().Object, new List<Span>());
+
+            var tagSpans = tagger.GetTags(spanCollection);
+
+            Assert.That(tagSpans, Is.Empty);
+        }
+
+        [Test]
+        public void GetTags_should_return_no_tag_when_the_tagger_is_already_disposed()
+        {
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            var tagger = new RosieViolationSquiggleTagger(tagAggregator.Object);
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(new Mock<ITextSnapshot>(), 0, 0);
+
+            tagger.Dispose();
+
+            var tagSpans = tagger.GetTags(spanCollection);
+
+            Assert.That(tagSpans, Is.Empty);
+        }
+
+        [Test]
+        public void GetTags_should_return_no_tag_for_no_rosie_violation_tag_aggregated()
+        {
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            tagAggregator
+                .Setup(a => a.GetTags(It.IsAny<NormalizedSnapshotSpanCollection>()))
+                .Returns(new List<IMappingTagSpan<RosieViolationTag>>());
+            var tagger = new RosieViolationSquiggleTagger(tagAggregator.Object);
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(new Mock<ITextSnapshot>(), 0, 0);
+
+            var tagSpans = tagger.GetTags(spanCollection);
+
+            Assert.That(tagSpans, Is.Empty);
+        }
+
+        [Test]
+        public void GetTags_should_return_correct_tags_having_filtered_out_tags_with_non_single_spans()
+        {
+            //Mock argument of GetTags()
+            var textSnapshot = new Mock<ITextSnapshot>();
+            textSnapshot.Setup(tss => tss.Length).Returns(50);
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(textSnapshot, 0, 0);
+
+            //Mock ITagAggregator<RosieViolationTag>
+            var tagAggregator = new Mock<ITagAggregator<RosieViolationTag>>();
+            var mappingSpanEmpty =
+                TaggingMockSupport.MockMappingSpan(textSnapshot, new NormalizedSnapshotSpanCollection());
+            var mappingSpanSingle =
+                TaggingMockSupport.MockMappingSpan(textSnapshot,
+                    TaggingMockSupport.CreateSpanCollection(textSnapshot, 0, 0));
+            var mappingSpanMulti =
+                TaggingMockSupport.MockMappingSpan(textSnapshot, CreateMultiSpanCollection(textSnapshot));
+
+            tagAggregator
+                .Setup(a => a.GetTags(It.IsAny<NormalizedSnapshotSpanCollection>()))
+                .Returns(new List<IMappingTagSpan<RosieViolationTag>>
+                {
+                    //Critical
+                    CreateMappingTagSpan(mappingSpanEmpty, "critical rule filtered", "critical filtered message",
+                        RosieSeverities.Critical),
+                    CreateMappingTagSpan(mappingSpanSingle, "critical rule", "critical message",
+                        RosieSeverities.Critical),
+                    //Error
+                    CreateMappingTagSpan(mappingSpanSingle, "error rule", "error message",
+                        RosieSeverities.Error),
+                    //Warning
+                    CreateMappingTagSpan(mappingSpanMulti, "warning rule filtered", "warning filtered message",
+                        RosieSeverities.Warning),
+                    CreateMappingTagSpan(mappingSpanSingle, "warning rule", "warning message",
+                        RosieSeverities.Warning),
+                    //Informational
+                    CreateMappingTagSpan(mappingSpanSingle, "informational rule", "informational message",
+                        "informational"),
+                    CreateMappingTagSpan(mappingSpanSingle, "unknown rule", "unknown message", "unknown"),
+                });
+            var tagger = new RosieViolationSquiggleTagger(tagAggregator.Object);
+
+            var tagSpans = tagger.GetTags(spanCollection).ToList();
+
+            Assert.That(tagSpans, Has.Count.EqualTo(5));
+            Assert.Multiple(() =>
+            {
+                Assert.That(tagSpans[0].Tag.ErrorType, Is.EqualTo("Rosie Violation Critical"));
+                Assert.That(tagSpans[0].Tag.ToolTipContent, Is.EqualTo("critical message"));
+
+                Assert.That(tagSpans[1].Tag.ErrorType, Is.EqualTo("Rosie Violation Error"));
+                Assert.That(tagSpans[1].Tag.ToolTipContent, Is.EqualTo("error message"));
+
+                Assert.That(tagSpans[2].Tag.ErrorType, Is.EqualTo("Rosie Violation Warning"));
+                Assert.That(tagSpans[2].Tag.ToolTipContent, Is.EqualTo("warning message"));
+
+                Assert.That(tagSpans[3].Tag.ErrorType, Is.EqualTo("Rosie Violation Informational"));
+                Assert.That(tagSpans[3].Tag.ToolTipContent, Is.EqualTo("informational message"));
+
+                Assert.That(tagSpans[4].Tag.ErrorType, Is.EqualTo("Rosie Violation Informational"));
+                Assert.That(tagSpans[4].Tag.ToolTipContent, Is.EqualTo("unknown message"));                
+            });
+        }
+
+        #region Mock and test object creation
+
+        /// <summary>
+        /// Creates a <c>NormalizedSnapshotSpanCollection</c> with multiple spans to test if those are
+        /// filtered out by the tag retrieval.
+        /// </summary>
+        private static NormalizedSnapshotSpanCollection CreateMultiSpanCollection(IMock<ITextSnapshot> textSnapshot)
+        {
+            //These offset values are arbitrary and not relevant for the tests 
+            return new NormalizedSnapshotSpanCollection(textSnapshot.Object,
+                new List<Span> { new Span(0, 5), new Span(6, 10) });
+        }
+
+        /// <summary>
+        /// Mocks a single item returned by <c>ITagAggregator.GetTags(NormalizedSnapshotSpanCollection)</c>
+        /// with the argument rule name, and message and severity set for the underlying <c>RosieViolation</c>.
+        /// </summary>
+        private static MappingTagSpan<RosieViolationTag> CreateMappingTagSpan(IMock<IMappingSpan> mappingSpan,
+            string ruleName, string message, string severity)
+        {
+            return new MappingTagSpan<RosieViolationTag>(
+                mappingSpan.Object,
+                new RosieViolationTag(
+                    new RosieAnnotation(ruleName, "ruleset-name",
+                        new RosieViolation { Message = message, Severity = severity })));
+        }
+
+        #endregion
+    }
+}

--- a/src/Tests/Rosie/Annotation/RosieViolationTaggerTest.cs
+++ b/src/Tests/Rosie/Annotation/RosieViolationTaggerTest.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Extension.Rosie;
+using Extension.Rosie.Annotation;
+using Extension.Rosie.Model;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using NUnit.Framework;
+using static Tests.TextBufferMockSupport;
+
+namespace Tests.Rosie.Annotation
+{
+    /// <summary>
+    /// Unit test for <see cref="RosieViolationTagger"/>.
+    /// </summary>
+    [TestFixture]
+    public class RosieViolationTaggerTest
+    {
+        [Test]
+        public async Task GetTags_should_return_no_tag_for_no_span()
+        {
+            var tagger = new RosieViolationTagger();
+            var spanCollection =
+                new NormalizedSnapshotSpanCollection(new Mock<ITextSnapshot>().Object, new List<Span>());
+        
+            var tagSpans = await tagger.GetTagsAsync(spanCollection);
+        
+            Assert.That(tagSpans, Is.Empty);
+        }
+        
+        [Test]
+        public async Task GetTags_should_return_no_tag_when_the_tagger_is_already_disposed()
+        {
+            var tagger = new RosieViolationTagger();
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(new Mock<ITextSnapshot>(), 0, 0);
+        
+            tagger.Dispose();
+        
+            var tagSpans = await tagger.GetTagsAsync(spanCollection);
+        
+            Assert.That(tagSpans, Is.Empty);
+        }
+        
+        [Test]
+        public async Task GetTags_should_return_no_tag_when_the_text_buffer_is_not_associated_with_a_filename()
+        {
+            var tagger =
+                new RosieViolationTagger(new TextBufferDataProvider { FileName = _ => null, IsTestMode = true });
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(new Mock<ITextSnapshot>(), 0, 0);
+        
+            var tagSpans = await tagger.GetTagsAsync(spanCollection);
+        
+            Assert.That(tagSpans, Is.Empty);
+        }
+        
+        [Test]
+        public async Task GetTags_should_return_no_tag_for_no_rosie_violation()
+        {
+            var tagger = new RosieViolationTagger(
+                new TextBufferDataProvider
+                    { FileName = _ => "python_file.py", IsTestMode = true });
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(new Mock<ITextSnapshot>(), 0, 0);
+        
+            var tagSpans = await tagger.GetTagsAsync(spanCollection);
+        
+            Assert.That(tagSpans, Is.Empty);
+        }
+        
+        [Test]
+        public async Task GetTags_should_filter_out_violations_out_of_document_range()
+        {
+            var textSnapshot = MockTextSnapshot(out var ignored);
+        
+            //Mock RosiePosition.GetOffset() for line 1
+            MockLineStartPosition(textSnapshot, 0, 10);
+            //Mock RosiePosition.GetOffset() to throw exception for line 2
+            textSnapshot.Setup(tss => tss.GetLineFromLineNumber(1)).Throws<ArgumentOutOfRangeException>();
+        
+            //Setup a non-empty span for the argument of GetTags()
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(textSnapshot, 21, 2);
+        
+            //Create the RosieAnnotations for violations returned from the server
+            var intersectingSpan = CreateRosieAnnotation("rule1", 1, 11, 1, 14);
+            var outOfRange = CreateRosieAnnotation("rule2", 2, 20, 2, 22);
+            
+            var tagger = new RosieViolationTagger(new TextBufferDataProvider
+                { FileName = _ => "python_file.py", IsTestMode = true });
+            tagger.Annotations = new List<RosieAnnotation> { intersectingSpan, outOfRange };
+        
+            var tagSpans = (await tagger.GetTagsAsync(spanCollection)).ToList();
+        
+            Assert.That(tagSpans, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(tagSpans[0].Span.Start.Position, Is.EqualTo(21));
+                Assert.That(tagSpans[0].Span.End.Position, Is.EqualTo(23));
+                Assert.That(tagSpans[0].Tag.Annotation, Is.EqualTo(intersectingSpan));
+            });
+        }
+        
+        [Test]
+        public async Task GetTags_should_filter_out_violations_not_intersecting_the_current_span()
+        {
+            var bufferContent = new TextBufferContent(@"contents
+here and there");
+            var textSnapshot = MockTextSnapshot(out var ignored, bufferContent, true);
+
+            //Setup a non-empty span for the argument of GetTags()
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(textSnapshot, 10, 5);
+        
+            //Create the RosieAnnotations for violations returned from the server
+            var beforeSpan = CreateRosieAnnotation("rule1", 1, 5, 1, 9);
+            var intersectingSpan = CreateRosieAnnotation("rule2", 2, 1, 2, 4);
+            var afterSpan = CreateRosieAnnotation("rule3", 2, 10, 2, 12);
+            
+            var tagger = new RosieViolationTagger(new TextBufferDataProvider
+                { FileName = _ => "python_file.py", IsTestMode = true });
+            tagger.Annotations = new List<RosieAnnotation> { beforeSpan, intersectingSpan, afterSpan };
+        
+            var tagSpans = (await tagger.GetTagsAsync(spanCollection)).ToList();
+        
+            Assert.That(tagSpans, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(tagSpans[0].Span.Start.Position, Is.EqualTo(10));
+                Assert.That(tagSpans[0].Span.End.Position, Is.EqualTo(13));
+                Assert.That(tagSpans[0].Tag.Annotation, Is.EqualTo(intersectingSpan));
+            });
+        }
+        
+        [Test]
+        public async Task GetTags_should_filter_out_violations_not_intersecting_empty_span()
+        {
+            var bufferContent = new TextBufferContent(@"contents
+here and there");
+            var textSnapshot = MockTextSnapshot(out var ignored, bufferContent, true);
+
+            //Setup an empty span for the argument of GetTags()
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(textSnapshot, 10, 0);
+        
+            //Create the RosieAnnotations for violations returned from the server
+            var beforeSpan = CreateRosieAnnotation("rule1", 1, 5, 1, 9);
+            var intersectingSpan = CreateRosieAnnotation("rule2", 2, 0, 2, 4);
+            var afterSpan = CreateRosieAnnotation("rule3", 2, 10, 2, 12);
+            
+            var tagger = new RosieViolationTagger(new TextBufferDataProvider
+                { FileName = _ => "python_file.py", IsTestMode = true });
+            tagger.Annotations = new List<RosieAnnotation> { beforeSpan, intersectingSpan, afterSpan };
+        
+            var tagSpans = (await tagger.GetTagsAsync(spanCollection)).ToList();
+        
+            Assert.That(tagSpans, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(tagSpans[0].Span.Start.Position, Is.EqualTo(10));
+                Assert.That(tagSpans[0].Span.End.Position, Is.EqualTo(10));
+                Assert.That(tagSpans[0].Tag.Annotation, Is.EqualTo(intersectingSpan));
+            });
+        }
+        
+        // ReSharper disable InconsistentNaming
+        [Test]
+        public async Task GetTags_should_return_tags()
+        {
+            var bufferContent = new TextBufferContent(@"contents
+here and there
+and over");
+            var textSnapshot = MockTextSnapshot(out var ignored, bufferContent, true);
+        
+            //Setup an empty span for the argument of GetTags()
+            var spanCollection = TaggingMockSupport.CreateSpanCollection(textSnapshot, 10, 15); //offset: 10-25
+        
+            //Create the RosieAnnotations for violations returned from the server
+            var start_lte_span_start_end_gte_span_end =
+                CreateRosieAnnotation("rule1", 1, 5, 3, 9);
+            var start_lte_span_start_end_lt_span_end =
+                CreateRosieAnnotation("rule2", 1, 5, 2, 4);
+            var start_gt_span_start_end_gte_span_end =
+                CreateRosieAnnotation("rule3", 2, 3, 3, 2);
+            var start_gt_span_start_end_lt_span_end =
+                CreateRosieAnnotation("rule4", 2, 3, 2, 6);
+            
+            var tagger = new RosieViolationTagger(new TextBufferDataProvider
+                { FileName = _ => "python_file.py", IsTestMode = true });
+            tagger.Annotations = new List<RosieAnnotation>
+            {
+                start_lte_span_start_end_gte_span_end,
+                start_lte_span_start_end_lt_span_end,
+                start_gt_span_start_end_gte_span_end,
+                start_gt_span_start_end_lt_span_end
+            };
+        
+            var tagSpans = (await tagger.GetTagsAsync(spanCollection)).ToList();
+        
+            Assert.That(tagSpans, Has.Count.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(tagSpans[0].Span.Start.Position, Is.EqualTo(10));
+                Assert.That(tagSpans[0].Span.End.Position, Is.EqualTo(25));
+                Assert.That(tagSpans[0].Tag.Annotation, Is.EqualTo(start_lte_span_start_end_gte_span_end));
+        
+                Assert.That(tagSpans[1].Span.Start.Position, Is.EqualTo(10));
+                Assert.That(tagSpans[1].Span.End.Position, Is.EqualTo(13));
+                Assert.That(tagSpans[1].Tag.Annotation, Is.EqualTo(start_lte_span_start_end_lt_span_end));
+        
+                Assert.That(tagSpans[2].Span.Start.Position, Is.EqualTo(12));
+                Assert.That(tagSpans[2].Span.End.Position, Is.EqualTo(25));
+                Assert.That(tagSpans[2].Tag.Annotation, Is.EqualTo(start_gt_span_start_end_gte_span_end));
+        
+                Assert.That(tagSpans[3].Span.Start.Position, Is.EqualTo(12));
+                Assert.That(tagSpans[3].Span.End.Position, Is.EqualTo(15));
+                Assert.That(tagSpans[3].Tag.Annotation, Is.EqualTo(start_gt_span_start_end_lt_span_end));
+            });
+        }
+        
+        #region Mock and test object creation
+        
+        /// <summary>
+        /// Creates a <c>RosieAnnotation</c> with the given rule name, and an underlying <c>RosieViolation</c>
+        /// with the provided start and end positions.
+        /// </summary>
+        private static RosieAnnotation CreateRosieAnnotation(string ruleName, int startLine, int startCol, int endLine,
+            int endCol)
+        {
+            return new RosieAnnotation(ruleName, "ruleset-name",
+                new RosieViolation
+                {
+                    Start = new RosiePosition { Line = startLine, Col = startCol },
+                    End = new RosiePosition { Line = endLine, Col = endCol }
+                });
+        }
+
+        #endregion
+    }
+}

--- a/src/Tests/Rosie/CodigaConfigFileUtilTest.cs
+++ b/src/Tests/Rosie/CodigaConfigFileUtilTest.cs
@@ -1,8 +1,7 @@
 using System.IO;
-using EnvDTE;
 using Extension.Rosie;
-using Moq;
 using NUnit.Framework;
+using static Tests.ServiceProviderMockSupport;
 
 namespace Tests.Rosie
 {
@@ -12,7 +11,6 @@ namespace Tests.Rosie
     [TestFixture]
     internal class CodigaConfigFileUtilTest
     {
-        private string _solutionDir;
         private string _codigaConfigFile;
 
         #region DeserializeConfig negative cases
@@ -160,9 +158,9 @@ rulesets:
         [Test]
         public void FindCodigaConfigFile_should_return_null_for_missing_solution_root()
         {
-            var solution = new Mock<Solution>();
+            var serviceProvider = MockServiceProvider("/");
 
-            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(solution.Object);
+            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(serviceProvider);
 
             Assert.That(configFile, Is.Null);
         }
@@ -170,11 +168,9 @@ rulesets:
         [Test]
         public void FindCodigaConfigFile_should_return_null_for_missing_codiga_config_file()
         {
-            var solution = new Mock<Solution>();
-            _solutionDir = Path.GetTempPath();
-            solution.Setup(s => s.FullName).Returns(_solutionDir);
+            var serviceProvider = MockServiceProvider(Path.GetTempPath());
 
-            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(solution.Object);
+            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(serviceProvider);
 
             Assert.That(configFile, Is.Null);
         }
@@ -182,18 +178,16 @@ rulesets:
         [Test]
         public void FindCodigaConfigFile_should_return_path_of_codiga_config_file()
         {
-            _solutionDir = Path.GetTempPath();
-            _codigaConfigFile = $"{_solutionDir}codiga.yml";
+            var serviceProvider = MockServiceProvider(Path.GetTempPath());
+            _codigaConfigFile = $"{Path.GetTempPath()}codiga.yml";
 
-            var solution = new Mock<Solution>();
-            solution.Setup(s => s.FullName).Returns(_solutionDir);
             using var fs = File.Create(_codigaConfigFile);
 
-            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(solution.Object);
+            var configFile = CodigaConfigFileUtil.FindCodigaConfigFile(serviceProvider);
 
             Assert.That(configFile, Is.EqualTo(_codigaConfigFile));
         }
-
+        
         #endregion
 
         #region Invalid ruleset names
@@ -232,8 +226,6 @@ rulesets:
         [TearDown]
         public void TearDown()
         {
-            if (File.Exists(_solutionDir))
-                File.Delete(_solutionDir);
             if (File.Exists(_codigaConfigFile))
                 File.Delete(_codigaConfigFile);
         }

--- a/src/Tests/Rosie/RosieClientTest.cs
+++ b/src/Tests/Rosie/RosieClientTest.cs
@@ -1,0 +1,82 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Extension.Rosie;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests.Rosie
+{
+    /// <summary>
+    /// Unit test for <see cref="RosieClient"/>.
+    /// </summary>
+    [TestFixture]
+    public class RosieClientTest
+    {
+        private string? _testFile;
+
+        [Test]
+        public async Task GetAnnotations_should_return_no_annotation_for_no_filename()
+        {
+            var rosieClient = new RosieClient(_ => null, _ => "");
+
+            var annotations = await rosieClient.GetAnnotations(new Mock<ITextBuffer>().Object);
+
+            Assert.That(annotations, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetAnnotations_should_return_no_annotation_for_non_existent_file()
+        {
+            var rosieClient = new RosieClient(_ => "", _ => "");
+
+            var annotations = await rosieClient.GetAnnotations(new Mock<ITextBuffer>().Object);
+
+            Assert.That(annotations, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetAnnotations_should_return_no_annotation_for_not_supported_file_language()
+        {
+            CreateTestFile("not_supported_file_type.xaml");
+            var rosieClient = new RosieClient(_ => _testFile, _ => "");
+
+            var annotations = await rosieClient.GetAnnotations(new Mock<ITextBuffer>().Object);
+
+            Assert.That(annotations, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetAnnotations_should_return_no_annotation_for_no_rule_returned_for_the_current_language()
+        {
+            CreateTestFile("python_file.py");
+            var rosieClient = new RosieClient(_ => _testFile, _ => "");
+            var textBuffer = new Mock<ITextBuffer>();
+
+            var annotations = await rosieClient.GetAnnotations(textBuffer.Object);
+
+            Assert.That(annotations, Is.Empty);
+        }
+
+        /// <summary>
+        /// Creates a file with the given file name in the current system's temp directory.
+        /// <br/>
+        /// This file acts as the currently edited document for which code analysis is performed. 
+        /// </summary>
+        private void CreateTestFile(string fileName)
+        {
+            _testFile = $"{Path.GetTempPath()}{fileName}";
+            var info = Encoding.UTF8.GetBytes("");
+            using var fs = File.Create(_testFile);
+            fs.Write(info, 0, info.Length);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_testFile != null)
+                File.Delete(_testFile);
+        }
+    }
+}

--- a/src/Tests/ServiceProviderMockSupport.cs
+++ b/src/Tests/ServiceProviderMockSupport.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+
+namespace Tests
+{
+    /// <summary>
+    /// Utility to create a mock <see cref="SVsServiceProvider"/>. 
+    /// </summary>
+    internal static class ServiceProviderMockSupport
+    {
+        //For delegating calls of Microsoft.VisualStudio.Shell.Interop.IVsSolution.GetSolutionInfo(out string, out string, out string)
+        private delegate void GetSolutionInfo(
+            out string pbstrSolutionDirectory,
+            out string pbstrSolutionFile,
+            out string pbstrUserOptsFile);
+
+        /// <summary>
+        /// Creates a mock <c>SVsServiceProvider</c> and delegates its <c>GetSolutionInfo()</c> method call
+        /// to a dedicated delegate method. 
+        /// </summary>
+        /// <param name="solutionDir">The solution directory path to be returned by <c>GetSolutionInfo()</c></param>
+        internal static SVsServiceProvider MockServiceProvider(string solutionDir)
+        {
+            var serviceProvider = new Mock<SVsServiceProvider>();
+            var solution = new Mock<IVsSolution>();
+            serviceProvider.Setup(sp => sp.GetService(typeof(SVsSolution))).Returns(solution.Object);
+
+            string dir, file, ops;
+            solution
+                .Setup(p => p.GetSolutionInfo(out dir, out file, out ops))
+                .Callback(new GetSolutionInfo((out string dir, out string file, out string ops) =>
+                {
+                    dir = solutionDir;
+                    file = "";
+                    ops = "";
+                }))
+                .Returns(1);
+            return serviceProvider.Object;
+        }
+    }
+}

--- a/src/Tests/TaggingMockSupport.cs
+++ b/src/Tests/TaggingMockSupport.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
+using Moq;
+
+namespace Tests
+{
+    /// <summary>
+    /// Utility for creating mocks for tagging related tests.
+    /// </summary>
+    public static class TaggingMockSupport
+    {
+        public static Mock<IMappingSpan> MockMappingSpan(
+            IMock<ITextSnapshot> textSnapshot,
+            NormalizedSnapshotSpanCollection spanCollection)
+        {
+            var mappingSpan = new Mock<IMappingSpan>();
+            mappingSpan
+                .Setup(ms => ms.GetSpans(textSnapshot.Object))
+                .Returns(spanCollection);
+            return mappingSpan;
+        }
+        
+        public static NormalizedSnapshotSpanCollection CreateSpanCollection(IMock<ITextSnapshot> textSnapshot,
+            int start, int length)
+        {
+            return new NormalizedSnapshotSpanCollection(
+                textSnapshot.Object,
+                new List<Span> { new Span(start, length) });
+        }
+    }
+}

--- a/src/Tests/TextBufferMockSupport.cs
+++ b/src/Tests/TextBufferMockSupport.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
+using Moq;
+
+namespace Tests
+{
+    public static class TextBufferMockSupport
+    {
+        /// <summary>
+        /// Creates a mock <c>ITextBuffer</c> with the provided <c>bufferText</c> as its content without mocking
+        /// the individual lines in the buffer.
+        /// <br/>
+        /// Any result of a violation fix edit will be saved into <c>bufferContent</c>.
+        /// </summary>
+        public static Mock<ITextBuffer> MockTextBuffer(string bufferText, out TextBufferContent bufferContent)
+        {
+            bufferContent = new TextBufferContent(bufferText);
+            var textSnapshot = MockTextSnapshot(out var textBuffer, bufferContent);
+            MockLineStartPosition(textSnapshot, 0, 0);
+            return textBuffer;
+        }
+
+        /// <summary>
+        /// Mocks an <c>ITextBuffer</c> with the buffer content's length (or an arbitrary one if no content provided),
+        /// as the document being tagged, and an <c>ITextSnapshot</c> that is returned by <c>ITextBuffer.CurrentSnapshot</c>.
+        /// <br/>
+        /// Optionally, depending on the test case, it mocks or not, the individual lines in the buffer.
+        /// </summary>
+        public static Mock<ITextSnapshot> MockTextSnapshot(out Mock<ITextBuffer> buffer, TextBufferContent? bufferContent = null, bool mockLines = false)
+        {
+            var textSnapshot = new Mock<ITextSnapshot>();
+            var textBuffer = new Mock<ITextBuffer>();
+            textSnapshot.Setup(tss => tss.Length).Returns(bufferContent != null ? bufferContent.Text.Length : 50);
+            textSnapshot.Setup(tss => tss.TextBuffer).Returns(textBuffer.Object);
+            textBuffer.Setup(b => b.CurrentSnapshot).Returns(textSnapshot.Object);
+            buffer = textBuffer;
+            
+            if (mockLines)
+                MockLines(bufferContent, textSnapshot);
+
+            //Mock modification interactions within the text buffer
+            MockInsertionInTextBuffer(textBuffer, bufferContent);
+            MockDeletionInTextBuffer(textBuffer, bufferContent);
+            MockReplacementInTextBuffer(textBuffer, bufferContent);
+            
+            return textSnapshot;
+        }
+
+        /// <summary>
+        /// Mocks all line's start and end positions in the buffer content, based on the positions of \n characters in the buffer text
+        /// </summary>
+        private static void MockLines(TextBufferContent bufferContent, Mock<ITextSnapshot> textSnapshot)
+        {
+            var indexes = new List<int>();
+            // for loop ends when i=-1 ('\n' not found)
+            for (var i = bufferContent.Text.IndexOf("\n"); i > -1; i = bufferContent.Text.IndexOf("\n", i + 1))
+                indexes.Add(i);
+
+            var lines = bufferContent.Text.Split('\n');
+            //First line always starts at 0
+            MockLine(textSnapshot, 0, 0, lines[0].Length + 1, bufferContent);
+            for (var i = 0; i <= indexes.Count - 1; i++)
+            {
+                MockLine(textSnapshot, 
+                    i + 1,
+                    indexes[i] + 1,
+                    //Line ends after the next \n character, or at the text buffer's end
+                    i < indexes.Count - 1 ? indexes[i + 1] + 1 : bufferContent.Text.Length,
+                    bufferContent);
+            }
+        }
+
+        /// <summary>
+        /// Mocks a single line for <c>RosiePosition.GetOffset()</c>, meaning a line with the given <c>lineNumber</c>
+        /// starts at the provided <c>startPosition</c>.
+        /// <br/>
+        /// Also mocks the same line and its content to be returned for a range of start and end positions,
+        /// that enclose that given line.
+        /// <br/>
+        /// The end position value should take into account and include the \r\n characters at the end of each line. 
+        /// </summary>
+        private static void MockLine(
+            Mock<ITextSnapshot> textSnapshot,
+            int lineNumber,
+            int start,
+            int end,
+            TextBufferContent bufferContent)
+        {
+            var snapshotLine = new Mock<ITextSnapshotLine>();
+            textSnapshot.Setup(tss => tss.GetLineFromLineNumber(lineNumber))
+                .Returns(snapshotLine.Object);
+            textSnapshot.Setup(tss => tss.GetLineFromPosition(It.IsInRange(start, end, Range.Inclusive)))
+                .Returns(snapshotLine.Object);
+
+            var lines = bufferContent.Text.Replace("\r", "").Split('\n');
+            snapshotLine.Setup(l => l.Start)
+                .Returns(new SnapshotPoint(textSnapshot.Object, start));
+            snapshotLine.Setup(l => l.End)
+                .Returns(new SnapshotPoint(textSnapshot.Object, end));
+            snapshotLine.Setup(l => l.LineNumber)
+                .Returns(lineNumber);
+            snapshotLine.Setup(l => l.GetText())
+                .Returns(lines[lineNumber]);
+        }
+        
+        /// <summary>
+        /// Mocks a single line for <c>RosiePosition.GetOffset()</c>, meaning a line with the given <c>lineNumber</c>
+        /// starts at the provided <c>startPosition</c>.
+        /// </summary>
+        public static void MockLineStartPosition(Mock<ITextSnapshot> textSnapshot, int lineNumber, int start)
+        {
+            var snapshotLine = new Mock<ITextSnapshotLine>();
+            textSnapshot.Setup(tss => tss.GetLineFromLineNumber(lineNumber))
+                .Returns(snapshotLine.Object);
+            snapshotLine.Setup(l => l.Start)
+                .Returns(new SnapshotPoint(textSnapshot.Object, start));
+        }
+
+        /// <summary>
+        /// Mocks the "add" edit type. It delegates the text insertion to a string object, and performs the edit
+        /// on <c>bufferContent</c>.
+        /// </summary>
+        private static void MockInsertionInTextBuffer(Mock<ITextBuffer> textBuffer, TextBufferContent bufferContent)
+        {
+            textBuffer
+                .Setup(tb => tb.Insert(It.IsAny<int>(), It.IsAny<string>()))
+                .Callback(new InvocationAction(invocation =>
+                    {
+                        bufferContent.Text = bufferContent.Text.Insert((int)invocation.Arguments[0],
+                            invocation.Arguments[1] as string);
+                    }
+                ));
+        }
+
+        /// <summary>
+        /// Mocks the "remove" edit type. It delegates the text insertion to a string object, and performs the edit
+        /// on <c>bufferContent</c>.
+        /// </summary>
+        private static void MockDeletionInTextBuffer(Mock<ITextBuffer> textBuffer, TextBufferContent bufferContent)
+        {
+            textBuffer
+                .Setup(tb => tb.Delete(It.IsAny<Span>()))
+                .Callback(new InvocationAction(invocation =>
+                    {
+                        var span = (Span)invocation.Arguments[0];
+                        bufferContent.Text = bufferContent.Text.Remove(span.Start, span.Length);
+                    }
+                ));
+        }
+
+        /// <summary>
+        /// Mocks the "update" edit type. It delegates the text insertion to a string object, and performs the edit
+        /// on <c>bufferContent</c>.
+        /// <br/>
+        /// The update operation is emulated by a string <c>Remove()</c> and <c>Insert()</c> call because string has
+        /// no counterpart of <c>ITextBuffer.Update()</c>.
+        /// </summary>
+        private static void MockReplacementInTextBuffer(Mock<ITextBuffer> textBuffer, TextBufferContent bufferContent)
+        {
+            textBuffer
+                .Setup(tb => tb.Replace(It.IsAny<Span>(), It.IsAny<string>()))
+                .Callback(new InvocationAction(invocation =>
+                    {
+                        var span = (Span)invocation.Arguments[0];
+                        var updated = bufferContent.Text.Remove(span.Start, span.Length);
+                        bufferContent.Text = updated.Insert(span.Start, invocation.Arguments[1] as string);
+                    }
+                ));
+        }
+
+        /// <summary>
+        /// A wrapper class to store the content of an <c>ITextBuffer</c> and the results of any violation fix edits.
+        /// </summary>
+        public class TextBufferContent
+        {
+            public string Text { get; set; }
+
+            public TextBufferContent(string text)
+            {
+                Text = text;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Changes
#### Fixes
- Tagging in `RosieViolationTagger` is skipped for annotations whose start offsets are greater than their end offsets.
- `CodigaConfigFileUtil` can now locate `codiga.yml` when a non-solution folder is open in VS.

#### Tests
- Added tests for
  - `RosieClient`
  - Lightbulb actions: `ApplyRosieFixSuggestedAction`, `DisableRosieAnalysisSuggestedAction`, `OpenOnCodigaHubSuggestedAction`
  - Taggers: `RosieViolationTagger`, `RosieViolationSquiggleTagger`
- Updated a handful of test methods with soft assertions (`Assert.Multiple()`).

### Notes
The tagging and lightbulb related tests use mocking and underlying string operations to emulate the behaviour in a text buffer and text snapshot.