### PR TITLE
#13: Record metric when a rule fix is applied.

### DIFF
--- a/src/Extension/Rosie/Annotation/RosieHighlightActionsSourceProvider.cs
+++ b/src/Extension/Rosie/Annotation/RosieHighlightActionsSourceProvider.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Extension.Caching;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -107,7 +108,7 @@ namespace Extension.Rosie.Annotation
             {
                 var rosieAnnotation = violation.Tag.Annotation;
                 foreach (var fix in rosieAnnotation.Fixes)
-                    actions.Add(new ApplyRosieFixSuggestedAction(range.Snapshot.TextBuffer, fix));
+                    actions.Add(new ApplyRosieFixSuggestedAction(range.Snapshot.TextBuffer, fix, new DefaultCodigaClientProvider()));
 
                 actions.Add(new DisableRosieAnalysisSuggestedAction(
                     rosieAnnotation,

--- a/src/GraphQLClient/CodigaClient.cs
+++ b/src/GraphQLClient/CodigaClient.cs
@@ -93,6 +93,11 @@ namespace GraphQLClient
 		/// <exception cref="CodigaAPIException"></exception>
 		/// <returns>The timestamp when the sent rulesets were last updated.</returns>
 		public Task<long> GetRulesetsLastUpdatedTimestampAsync(IReadOnlyCollection<string> names);
+		
+		/// <summary>
+		/// Sends a request to Codiga that a rule fix quick fix was invoked by the user.
+		/// </summary>
+		public Task<string> RecordRuleFixAsync();
 	}
 
 	public class CodigaClient : ICodigaClient, IDisposable
@@ -283,6 +288,20 @@ namespace GraphQLClient
 			return result.Data.RuleSetsLastUpdatedTimestamp;
 		}
 
+		public async Task<string> RecordRuleFixAsync()
+		{
+			dynamic variables = new System.Dynamic.ExpandoObject();
+			var variablesDict = (IDictionary<string, object?>)variables;
+			variablesDict["fingerprint"] = Fingerprint;
+
+			var request = new GraphQLHttpRequest(QueryProvider.RecordRuleFixMutation, variables);
+			var result = await _client.SendMutationAsync<RecordRuleFixMutationResult>(request);
+
+			ThrowOnErrors(result);
+			
+			return result.Data.RecordAccess;
+		}
+
 		public void Dispose()
 		{
 			_client?.Dispose();
@@ -349,6 +368,11 @@ namespace GraphQLClient
 	}
 
 	internal class RecordRecipeUseMutationResult
+	{
+		public string? RecordAccess { get; set; }
+	}
+	
+	internal class RecordRuleFixMutationResult
 	{
 		public string? RecordAccess { get; set; }
 	}

--- a/src/GraphQLClient/GraphQLClient.csproj
+++ b/src/GraphQLClient/GraphQLClient.csproj
@@ -26,7 +26,7 @@
     <GraphQLConfig Include="queries\IgnoreViolation.graphql" />
     <GraphQLConfig Include="queries\RecordAccess.graphql" />
     <GraphQLConfig Include="queries\RecordRecipeUse.graphql" />
-    <GraphQLConfig Include="queries\RecordRecipeUse.graphql" />
+    <GraphQLConfig Include="queries\RecordRuleFix.graphql" />
     <GraphQLConfig Include="queries\GetRulesetsForClient.graphql" />
     <GraphQLConfig Include="queries\GetRulesetsForClientLastTimestamp.graphql" />
     <GraphQLConfig Include="queries\RemoveViolationToIgnore.graphql" />
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <AdditionalFiles Remove="queries\RecordRecipeUse.graphql" />
+    <AdditionalFiles Remove="queries\RecordRuleFix.graphql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -62,6 +63,7 @@
     <None Remove="Queries\GetRecipesForClientSemantic.graphql" />
     <None Remove="Queries\GetUser.graphql" />
     <None Remove="Queries\RecordRecipeUse.graphql" />
+    <None Remove="Queries\RecordRuleFix.graphql" />
     <None Remove="Queries\GetRulesetsForClient.graphql" />
     <None Remove="Queries\GetRulesetsForClientLastTimestamp.graphql" />
   </ItemGroup>
@@ -72,6 +74,7 @@
     <EmbeddedResource Include="Queries\GetRecipesForClientSemantic.graphql" />
     <EmbeddedResource Include="Queries\GetUser.graphql" />
     <EmbeddedResource Include="Queries\RecordRecipeUse.graphql" />
+    <EmbeddedResource Include="Queries\RecordRuleFix.graphql" />
     <EmbeddedResource Include="Queries\GetRulesetsForClient.graphql" />
     <EmbeddedResource Include="Queries\GetRulesetsForClientLastTimestamp.graphql" />
   </ItemGroup>

--- a/src/GraphQLClient/Queries/RecordRuleFix.graphql
+++ b/src/GraphQLClient/Queries/RecordRuleFix.graphql
@@ -1,0 +1,3 @@
+mutation RecordRuleFix($fingerprint: String) {
+    recordAccess(accessType: IntelliJ, actionType: RuleFix, userFingerprint: $fingerprint)
+}

--- a/src/GraphQLClient/Queries/RecordRuleFix.graphql
+++ b/src/GraphQLClient/Queries/RecordRuleFix.graphql
@@ -1,3 +1,3 @@
 mutation RecordRuleFix($fingerprint: String) {
-    recordAccess(accessType: IntelliJ, actionType: RuleFix, userFingerprint: $fingerprint)
+    recordAccess(accessType: VisualStudio, actionType: RuleFix, userFingerprint: $fingerprint)
 }

--- a/src/GraphQLClient/QueryProvider.cs
+++ b/src/GraphQLClient/QueryProvider.cs
@@ -21,6 +21,7 @@ namespace GraphQLClient
 		private const string GetUserQueryFile = Namespace + "GetUser.graphql";
 		private const string GetRulesetsForClientQueryFile = Namespace + "GetRulesetsForClient.graphql";
 		private const string GetRulesetsLastUpdatedTimestampQueryFile = Namespace + "GetRulesetsForClientLastTimestamp.graphql";
+		private const string RecordRuleFixMutationFile = Namespace + "RecordRuleFix.graphql";
 
 		public static string ShortcutQuery { get; }
 		public static string ShortcutLastTimestampQuery { get; }
@@ -29,6 +30,7 @@ namespace GraphQLClient
 		public static string GetUserQuery { get; }
 		public static string GetRulesetsForClientQuery { get; }
 		public static string GetRulesetsLastUpdatedTimestampQuery { get; }
+		public static string RecordRuleFixMutation { get; }
 
 		static QueryProvider()
 		{
@@ -74,6 +76,12 @@ namespace GraphQLClient
 			{
 				using StreamReader reader = new StreamReader(stream);
 				GetRulesetsLastUpdatedTimestampQuery = reader.ReadToEnd();
+			}
+			
+			using (Stream stream = assembly.GetManifestResourceStream(RecordRuleFixMutationFile))
+			{
+				using StreamReader reader = new StreamReader(stream);
+				RecordRuleFixMutation = reader.ReadToEnd();
 			}
 		}
 	}

--- a/src/Tests/TestCodigaClient.cs
+++ b/src/Tests/TestCodigaClient.cs
@@ -62,7 +62,12 @@ namespace Tests
         {
             return await Task.FromResult(RulesetsForClientTestSupport.GetRulesetsLastTimestamp(names));
         }
-        
+
+        public async Task<string> RecordRuleFixAsync()
+        {
+            return await Task.FromResult<string>(null);
+        }
+
         public void Dispose()
         {
         }


### PR DESCRIPTION
### Changes
- GraphQL
  - Added a new mutations for the rule fix record.
- Sending a metric when a rule fix is applied in `ApplyRosieFixSuggestedAction`.

### Notes
- JetBrains implementation of the metrics: https://github.com/codiga/jetbrains-plugin/pull/225