### PR TITLE
Typescript support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -148,6 +148,17 @@ request to the Rosie server. This way, it is initialized only when code analysis
 
 For response/request (de)serialization, you can find the model classes in the `Extension.Rosie.Model` namespace.
 
+### Adding new rule AST types
+
+You can add new constants and mappings for the new types in [`RosieRuleAstTypes`](/src/Extension/Rosie/Model/RosieRuleAstTypes.cs).
+
+### Adding support for new Rosie languages
+
+First, you need to add the new language(s) in [`RosieLanguageSupport.SupportedLanguages`](/src/Extension/Rosie/RosieLanguageSupport.cs)
+and [`RosieLanguageSupport.GetRosieLanguage`](/src/Extension/Rosie/RosieLanguageSupport.cs).
+
+If a language needs special treatment on the caching part, make sure to update at least [`RosieRulesCache.GetCachedLanguageTypeOf`](/src/Extension/Rosie/RosieRulesCache).
+
 ### Tagging
 
 #### Tagging in general in Visual Studio extensions

--- a/src/Extension/Extension.csproj
+++ b/src/Extension/Extension.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Rosie\Annotation\RosieViolationTagger.cs" />
     <Compile Include="Rosie\Annotation\RosieViolationTaggerProvider.cs" />
     <Compile Include="Rosie\Annotation\StringUtils.cs" />
+    <Compile Include="Rosie\Model\RosieRuleAstTypes.cs" />
     <Compile Include="Rosie\RosieClientProvider.cs" />
     <Compile Include="Rosie\CodigaCodeAnalysisConfig.cs" />
     <Compile Include="Rosie\CodigaConfigFileUtil.cs" />

--- a/src/Extension/Rosie/Model/RosieRule.cs
+++ b/src/Extension/Rosie/Model/RosieRule.cs
@@ -4,19 +4,6 @@ namespace Extension.Rosie.Model
 {
     public class RosieRule
     {
-        private const string EntityCheckedFunctionCall = "functioncall";
-        private const string EntityCheckedIfCondition = "ifcondition";
-        private const string EntityCheckedImport = "import";
-        private const string EntityCheckedAssignment = "assign";
-        private const string EntityCheckedForLoop = "forloop";
-        private const string EntityCheckedFunctionDefinition = "functiondefinition";
-        private const string EntityCheckedTryBlock = "tryblock";
-        private const string EntityCheckedType = "type";
-        private const string EntityCheckedInterface = "interface";
-        private const string EntityCheckedHtmlElement = "htmlelement";
-        private const string EntityCheckedClassDefinition = "classdefinition";
-        private const string EntityCheckedFunctionExpression = "functionexpression";
-        
         public string Id { get; }
         public string ContentBase64 { get; }
         public string Language { get; }
@@ -29,31 +16,8 @@ namespace Extension.Rosie.Model
             ContentBase64 = rule.Content;
             Language = rule.Language;
             Type = rule.RuleType;
-            EntityChecked = ElementCheckedToRosieEntityChecked(rule.ElementChecked);
+            EntityChecked = RosieRuleAstTypes.ElementCheckedToRosieEntityChecked(rule.ElementChecked);
             Pattern = rule.Pattern;
-        }
-
-        private string? ElementCheckedToRosieEntityChecked(string? elementChecked) {
-            if (elementChecked == null) {
-                return null;
-            }
-            
-            return elementChecked switch
-            {
-                "ForLoop" => EntityCheckedForLoop,
-                "Assignment" => EntityCheckedAssignment,
-                "FunctionDefinition" => EntityCheckedFunctionDefinition,
-                "TryBlock" => EntityCheckedTryBlock,
-                "Import" => EntityCheckedImport,
-                "IfCondition" => EntityCheckedIfCondition,
-                "FunctionCall" => EntityCheckedFunctionCall,
-                "Type" => EntityCheckedType,
-                "Interface" => EntityCheckedInterface,
-                "HtmlElement" => EntityCheckedHtmlElement,
-                "ClassDefinition" => EntityCheckedClassDefinition,
-                "FunctionExpression" => EntityCheckedFunctionExpression,
-                _ => null
-            };
         }
     }
 }

--- a/src/Extension/Rosie/Model/RosieRuleAstTypes.cs
+++ b/src/Extension/Rosie/Model/RosieRuleAstTypes.cs
@@ -1,0 +1,47 @@
+namespace Extension.Rosie.Model
+{
+    /// <summary>
+    /// Provides values and mapping logic for rule AST types.
+    /// </summary>
+    internal static class RosieRuleAstTypes
+    {
+        private const string EntityCheckedFunctionCall = "functioncall";
+        private const string EntityCheckedIfCondition = "ifcondition";
+        private const string EntityCheckedImport = "import";
+        private const string EntityCheckedAssignment = "assign";
+        private const string EntityCheckedForLoop = "forloop";
+        private const string EntityCheckedFunctionDefinition = "functiondefinition";
+        private const string EntityCheckedTryBlock = "tryblock";
+        private const string EntityCheckedType = "type";
+        private const string EntityCheckedInterface = "interface";
+        private const string EntityCheckedHtmlElement = "htmlelement";
+        private const string EntityCheckedClassDefinition = "classdefinition";
+        private const string EntityCheckedFunctionExpression = "functionexpression";
+        
+        /// <summary>
+        /// Maps the argument element checked to its Rosie counterpart value.
+        /// </summary>
+        internal static string? ElementCheckedToRosieEntityChecked(string? elementChecked) {
+            if (elementChecked == null) {
+                return null;
+            }
+            
+            return elementChecked switch
+            {
+                "ForLoop" => EntityCheckedForLoop,
+                "Assignment" => EntityCheckedAssignment,
+                "FunctionDefinition" => EntityCheckedFunctionDefinition,
+                "TryBlock" => EntityCheckedTryBlock,
+                "Import" => EntityCheckedImport,
+                "IfCondition" => EntityCheckedIfCondition,
+                "FunctionCall" => EntityCheckedFunctionCall,
+                "Type" => EntityCheckedType,
+                "Interface" => EntityCheckedInterface,
+                "HtmlElement" => EntityCheckedHtmlElement,
+                "ClassDefinition" => EntityCheckedClassDefinition,
+                "FunctionExpression" => EntityCheckedFunctionExpression,
+                _ => null
+            };
+        }
+    }
+}

--- a/src/Extension/Rosie/RosieLanguageSupport.cs
+++ b/src/Extension/Rosie/RosieLanguageSupport.cs
@@ -53,7 +53,7 @@ namespace Extension.Rosie
             {
                 LanguageEnumeration.Python => "python",
                 LanguageEnumeration.Javascript => "javascript",
-                LanguageEnumeration.Typescript => "javascript",
+                LanguageEnumeration.Typescript => "typescript",
                 _ => "unknown"
             };
         }

--- a/src/Extension/Rosie/RosieRulesCache.cs
+++ b/src/Extension/Rosie/RosieRulesCache.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Community.VisualStudio.Toolkit;
-using EnvDTE;
 using Extension.Caching;
 using Extension.Rosie.Annotation;
 using Extension.Rosie.Model;
@@ -29,7 +28,6 @@ namespace Extension.Rosie
 
         private ICodigaClientProvider _clientProvider;
         private CancellationTokenSource _cancellationTokenSource;
-        private DTE _dte;
         
         /// <summary>
         /// Mapping the rules to their target languages, because this way
@@ -120,7 +118,6 @@ namespace Extension.Rosie
             //Retrieve the DTE object from which the Solution can be accessed
             ThreadHelper.ThrowIfNotOnUIThread();
             _serviceProvider = VS.GetMefService<SVsServiceProvider>();
-            _dte = (_DTE)_serviceProvider.GetService(typeof(_DTE));
 
             PollRulesetsAsync(_cancellationTokenSource.Token);
         }

--- a/src/Tests/Rosie/RosieLanguageSupportTest.cs
+++ b/src/Tests/Rosie/RosieLanguageSupportTest.cs
@@ -33,15 +33,7 @@ namespace Tests.Rosie
 
             Assert.That(language, Is.EqualTo("python"));
         }
-        
-        [Test]
-        public void GetRosieLanguage_should_return_javascript_language_string_for_typescript()
-        {
-            var language = RosieLanguageSupport.GetRosieLanguage(LanguageUtils.LanguageEnumeration.Typescript);
 
-            Assert.That(language, Is.EqualTo("javascript"));
-        }
-        
         [Test]
         public void GetRosieLanguage_should_return_unknown_for_not_supported_language()
         {


### PR DESCRIPTION
### Changes
- Using `typescript` language for TS files.
- Extracted AST type handling to a separate class called `RosieRuleAstTypes`.
- When there is at least one rule returned in a `RosieResponse`, no annotations will be shown.
- Added documentation on introducing new AST types and new Rosie languages.
- Removed an unused field in `RosieRulesCache`.