### PR TITLE
Add more details to Rollbar report when snippet is not found

### DIFF
--- a/src/Extension/Logging/ExtensionLogger.cs
+++ b/src/Extension/Logging/ExtensionLogger.cs
@@ -47,6 +47,20 @@ namespace Extension.Logging
 
 			return logger;
 		}
+		
+		public static ILogger LogException(Exception exception, string fileExtension, string snippetName)
+		{
+			var parameters = new Dictionary<string, object>
+			{
+				{ "Source", exception.Source }, { "FileExtension", fileExtension }, { "SnippetName", snippetName }
+			};
+
+			var logger = RollbarLocator.RollbarInstance.Error(exception, parameters);
+
+			LogActivityError(exception);
+
+			return logger;
+		}
 
 		public static ILogger LogWarning(string message)
 		{


### PR DESCRIPTION
### Changes
- Added a new exception type `CouldNotFindSnippetException`, and a new `LogException` method to report additional details for issue investigation purposes.