### PR TITLE
Python default rulesets

### DIFF
--- a/src/Extension/Extension.csproj
+++ b/src/Extension/Extension.csproj
@@ -77,7 +77,6 @@
     <Compile Include="Rosie\Annotation\StringUtils.cs" />
     <Compile Include="Rosie\CodigaDefaultRulesetsInfoBarHelper.cs" />
     <Compile Include="Rosie\CodigaRulesetConfigs.cs" />
-    <Compile Include="Rosie\Model\RosieRuleAstTypes.cs" />
     <Compile Include="Rosie\RosieClientProvider.cs" />
     <Compile Include="Rosie\CodigaCodeAnalysisConfig.cs" />
     <Compile Include="Rosie\CodigaConfigFileUtil.cs" />

--- a/src/Extension/Extension.csproj
+++ b/src/Extension/Extension.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Caching\CodigaClientProvider.cs" />
     <Compile Include="Caching\SnippetCache.cs" />
     <Compile Include="Caching\TextViewCreationListener.cs" />
+    <Compile Include="Helpers\SolutionHelper.cs" />
     <Compile Include="Logging\ExtensionLogger.cs" />
     <Compile Include="Rosie\Annotation\RosieViolationSquiggleTag.cs" />
     <Compile Include="Rosie\Annotation\RosieViolationSquiggleTaggerProvider.cs" />
@@ -74,6 +75,8 @@
     <Compile Include="Rosie\Annotation\RosieViolationTagger.cs" />
     <Compile Include="Rosie\Annotation\RosieViolationTaggerProvider.cs" />
     <Compile Include="Rosie\Annotation\StringUtils.cs" />
+    <Compile Include="Rosie\CodigaDefaultRulesetsInfoBarHelper.cs" />
+    <Compile Include="Rosie\CodigaRulesetConfigs.cs" />
     <Compile Include="Rosie\Model\RosieRuleAstTypes.cs" />
     <Compile Include="Rosie\RosieClientProvider.cs" />
     <Compile Include="Rosie\CodigaCodeAnalysisConfig.cs" />
@@ -87,6 +90,7 @@
     <Compile Include="Rosie\Model\RosieRequest.cs" />
     <Compile Include="Rosie\Model\RosieResponse.cs" />
     <Compile Include="Rosie\Model\RosieRule.cs" />
+    <Compile Include="Rosie\Model\RosieRuleAstTypes.cs" />
     <Compile Include="Rosie\Model\RosieRuleResponse.cs" />
     <Compile Include="Rosie\Model\RosieViolation.cs" />
     <Compile Include="Rosie\Model\RosieViolationFix.cs" />
@@ -122,6 +126,7 @@
       <DependentUpon>SnippetSearchPackage.vsct</DependentUpon>
     </Compile>
     <Compile Include="Settings\EditorSettings.cs" />
+    <Compile Include="Settings\SolutionSettings.cs" />
     <Compile Include="Settings\ExtensionOptions.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/Extension/ExtensionPackage.cs
+++ b/src/Extension/ExtensionPackage.cs
@@ -30,6 +30,9 @@ namespace Extension
 		/// </summary>
 		public const string PackageGuidString = "e8d2d8f8-96dc-4c92-bb81-346b4d2318e4";
 
+		private static readonly CodigaDefaultRulesetsInfoBarHelper.InfoBarHolder InfoBarHolder =
+			new CodigaDefaultRulesetsInfoBarHelper.InfoBarHolder();
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ExtensionPackage"/> class.
 		/// </summary>
@@ -72,7 +75,7 @@ namespace Extension
 
 		private void HandleOpenSolution(object sender = null, EventArgs e = null)
 		{
-			CodigaDefaultRulesetsInfoBarHelper.ShowDefaultRulesetCreationInfoBarAsync();
+			CodigaDefaultRulesetsInfoBarHelper.ShowDefaultRulesetCreationInfoBarAsync(InfoBarHolder);
 		}
 
 		public override IVsAsyncToolWindowFactory GetAsyncToolWindowFactory(Guid toolWindowType)
@@ -95,16 +98,18 @@ namespace Extension
 
 			return base.GetToolWindowTitle(toolWindowType, id);
 		}
-		
-		private void DoAdditionalInitialization(object sender, OpenSolutionEventArgs e)
+
+		private void DoAdditionalInitialization(object sender, EventArgs e)
 		{
-			CodigaDefaultRulesetsInfoBarHelper.ShowDefaultRulesetCreationInfoBarAsync();
+			CodigaDefaultRulesetsInfoBarHelper.ShowDefaultRulesetCreationInfoBarAsync(InfoBarHolder);
 		}
 
 		private static void CleanupCachesAndServices(object sender, EventArgs e)
 		{
             RosieRulesCache.Dispose();
-        }
+            InfoBarHolder.InfoBar?.Close();
+            InfoBarHolder.InfoBar = null;
+		}
 
 		#endregion
 	}

--- a/src/Extension/Helpers/SolutionHelper.cs
+++ b/src/Extension/Helpers/SolutionHelper.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Extension.Helpers
+{
+    /// <summary>
+    /// Utility to handle different aspects of a solution.
+    /// </summary>
+    internal static class SolutionHelper
+    {
+        /// <summary>
+        /// Returns the solution's root dir, or in Open Folder mode, the open folder's path.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider to retrieve information about the solution from.</param>
+        /// <returns></returns>
+        internal static string? GetSolutionDir(SVsServiceProvider serviceProvider)
+        {
+            var sol = (IVsSolution)serviceProvider.GetService(typeof(SVsSolution));
+            //'dir' contains the solution's directory path, or the open folder's path when it is a folder that's open, and not a solution
+            sol.GetSolutionInfo(out string dir, out string file, out string ops);
+            return Path.GetDirectoryName(dir);
+        }
+    }
+}

--- a/src/Extension/Rosie/CodigaConfigFileUtil.cs
+++ b/src/Extension/Rosie/CodigaConfigFileUtil.cs
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Extension.Helpers;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -44,12 +44,7 @@ namespace Extension.Rosie
         /// <returns>The path of the config file, or null if it doesn't exist.</returns>
         public static string? FindCodigaConfigFile(SVsServiceProvider serviceProvider)
         {
-            var sol = (IVsSolution)serviceProvider.GetService(typeof(SVsSolution));
-
-            // 'dir' contains the solution's directory path, or the open folder's path when it is a folder that's open, and not a solution
-            sol.GetSolutionInfo(out var dir, out var file, out var ops);
-
-            var solutionRoot = Path.GetDirectoryName(dir);
+            var solutionRoot = SolutionHelper.GetSolutionDir(serviceProvider);
             if (solutionRoot == null)
                 return null;
 
@@ -58,6 +53,17 @@ namespace Extension.Rosie
                 .FirstOrDefault();
 
             return codigaConfigFile != null && File.Exists(codigaConfigFile) ? codigaConfigFile : null;
+        }
+
+        /// <summary>
+        /// Creates the Codiga config file in the solution's root directory with default Python rulesets.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider to retrieve information about the solution from.</param>
+        public static void CreateCodigaConfigFile(SVsServiceProvider serviceProvider)
+        {
+            var solutionRoot = SolutionHelper.GetSolutionDir(serviceProvider);;
+            if (solutionRoot != null)
+                File.WriteAllText($"{solutionRoot}\\codiga.yml", CodigaRulesetConfigs.DefaultPythonRulesetConfig);
         }
 
         /// <summary>

--- a/src/Extension/Rosie/CodigaDefaultRulesetsInfoBarHelper.cs
+++ b/src/Extension/Rosie/CodigaDefaultRulesetsInfoBarHelper.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Extension.Caching;
+using Extension.Settings;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Extension.Rosie
+{
+    /// <summary>
+    /// Handles the analysis of the current solution/folder, and displays an info bar in the Solution Explorer when necessary.
+    /// </summary>
+    /// <seealso cref="https://learn.microsoft.com/en-us/visualstudio/extensibility/ux-guidelines/notifications-and-progress-for-visual-studio?view=vs-2022#BKMK_EmbeddedInfobar"/>
+    /// <seealso cref="https://learn.microsoft.com/en-us/visualstudio/extensibility/vsix/recipes/notifications?view=vs-2022"/>
+    /// <seealso cref="https://stackoverflow.com/questions/49278306/how-do-i-find-the-open-folder-in-a-vsix-extension"/>
+    internal static class CodigaDefaultRulesetsInfoBarHelper
+    {
+        //\n characters are for better formatting of the entire content of the info bar
+        private const string InfoBarText = "Check for security, code style in your Python code with Codiga.\n";
+        private const string CreateCodigaYmlActionText = "Create codiga.yml\n";
+        private const string NeverForThisSolutionActionText = "Never for this solution";
+
+        /// <summary>
+        /// Displays an info bar in the Solution Explorer with the following options:
+        /// <ul>
+        ///     <li>Create codiga.yml</li>
+        ///     <li>Never for this solution</li>
+        /// </ul>
+        /// <br/>
+        /// The info bar is displayed when all the following conditions are met:
+        /// <ol>
+        ///     <li>The user hasn't clicked the <strong>Never for this solution</strong> option.</li>
+        ///     <li>There is no Codiga config file in the solution root/open folder.</li>
+        ///     <li>At least one of the projects in the solution is a Python project.</li>
+        /// </ol>
+        /// </summary>
+        internal static async void ShowDefaultRulesetCreationInfoBarAsync()
+        {
+            var serviceProvider = await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return await VS.GetMefServiceAsync<SVsServiceProvider>();
+            });
+
+            if (SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider)
+                && CodigaConfigFileUtil.FindCodigaConfigFile(serviceProvider) == null
+                && await IsSolutionContainPythonProject(serviceProvider))
+            {
+                var model = new InfoBarModel(new[]
+                {
+                    new InfoBarTextSpan(InfoBarText),
+                    new InfoBarHyperlink(CreateCodigaYmlActionText),
+                    new InfoBarHyperlink(NeverForThisSolutionActionText)
+                }, KnownMonikers.PlayStepGroup);
+
+                var infoBar = await VS.InfoBar.CreateAsync(ToolWindowGuids80.SolutionExplorer, model);
+                if (infoBar != null)
+                {
+                    infoBar.ActionItemClicked += InfoBar_ActionItemClicked;
+                    await infoBar.TryShowInfoBarUIAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles when the user clicks one of the items in the info bar.
+        /// </summary>
+        private static void InfoBar_ActionItemClicked(object sender, InfoBarActionItemEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            switch (e.ActionItem.Text)
+            {
+                case CreateCodigaYmlActionText:
+                    RecordCreateCodigaYaml();
+                    CodigaConfigFileUtil.CreateCodigaConfigFile(VS.GetMefService<SVsServiceProvider>());
+                    break;
+                case NeverForThisSolutionActionText:
+                    SolutionSettings.SaveNeverNotifyUserToCreateCodigaConfigFile(
+                        VS.GetMefService<SVsServiceProvider>());
+                    break;
+            }
+
+            //Whichever action is clicked, close the info bar
+            e.InfoBarUIElement.Close();
+        }
+
+        private static void RecordCreateCodigaYaml()
+        {
+            var clientProvider = new DefaultCodigaClientProvider();
+            if (!clientProvider.TryGetClient(out var client))
+                return;
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                try
+                {
+                    await client.RecordCreateCodigaYaml();
+                }
+                catch
+                {
+                    //Even if recording this metric fails, the Codiga config file must be created
+                }
+            });
+        }
+
+        /// <summary>
+        /// Returns whether any of the projects in the current solution is a Python project.
+        /// <br/>
+        /// Python project guid comes from https://github.com/microsoft/PTVS/blob/main/Python/Product/VSCommon/CommonGuidList.cs
+        /// </summary>
+        /// <param name="serviceProvider">The service provider to retrieve information about the solution from.</param>
+        private static async Task<bool> IsSolutionContainPythonProject(SVsServiceProvider serviceProvider)
+        {
+            var solution = await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return (IVsSolution)serviceProvider.GetService(typeof(SVsSolution));
+            });
+
+            solution.GetProperty((int)__VSPROPID7.VSPROPID_IsInOpenFolderMode, out object isInFolderMode);
+
+            //If we have a proper VS solution open, check if at least one of the projects in it is a Python project
+            if (!(bool)isInFolderMode)
+            {
+                var projectsInSolution =
+                    ThreadHelper.JoinableTaskFactory.Run(async () => await VS.Solutions.GetAllProjectsAsync());
+                return projectsInSolution.Any(project =>
+                    ThreadHelper.JoinableTaskFactory.Run(async () =>
+                        await project.IsKindAsync("888888A0-9F3D-457C-B088-3A5042F75D52")));
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Extension/Rosie/CodigaRulesetConfigs.cs
+++ b/src/Extension/Rosie/CodigaRulesetConfigs.cs
@@ -1,0 +1,14 @@
+namespace Extension.Rosie
+{
+    /// <summary>
+    /// Provides default ruleset configurations for the Codiga config file.
+    /// </summary>
+    public static class CodigaRulesetConfigs
+    {
+        public const string DefaultPythonRulesetConfig =
+            "rulesets:\n" +
+            "  - python-security\n" +
+            "  - python-best-practices\n" +
+            "  - python-code-style";
+    }
+}

--- a/src/Extension/Settings/SolutionSettings.cs
+++ b/src/Extension/Settings/SolutionSettings.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using System.Linq;
+using Extension.Helpers;
+using Microsoft.VisualStudio.Shell;
+using Newtonsoft.Json;
+
+namespace Extension.Settings
+{
+    /// <summary>
+    /// Provides functionality to save solution specific configuration (as opposed to application specific ones)
+    /// for anything related to Codiga.
+    /// <br/>
+    /// The settings file is saved in the <c>{solution_root}\.vs</c> directory that is created automatically for each Visual Studio solution,
+    /// or when a non-solution project folder is opened, so that users don't have to explicitly deal with this config file,
+    /// for example .gitignore it, because it will be out of sight. 
+    /// </summary>
+    public static class SolutionSettings
+    {
+        private const string SolutionSettingsFileName = "CodigaSolutionSettings.json";
+
+        /// <summary>
+        /// Retrieves whether the user has already chosen to never be notified about the creation of
+        /// the Codiga config file.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider to retrieve information about the solution from.</param>
+        /// <returns>True if the user should be notified, false otherwise.</returns>
+        internal static bool IsShouldNotifyUserToCreateCodigaConfig(SVsServiceProvider serviceProvider)
+        {
+            var solutionSettingsFile = FindSolutionSettingsFile(serviceProvider);
+            if (solutionSettingsFile == null)
+                return true;
+
+            try
+            {
+                var solutionSettings =
+                    JsonConvert.DeserializeObject<SolutionSettingsFile>(File.ReadAllText(solutionSettingsFile));
+                return solutionSettings?.ShouldNotifyUserToCreateCodigaConfig ?? true;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Called when the user choses the <c>Never for this solution</c> option in the related info bar.
+        /// <br/>
+        /// It saves the user's choice to no longer show the info bar regarding the Codiga config creation.
+        /// </summary>
+        internal static void SaveNeverNotifyUserToCreateCodigaConfigFile(
+            SVsServiceProvider serviceProvider)
+        {
+            var dotVsDirectory = $"{SolutionHelper.GetSolutionDir(serviceProvider)}\\.vs";
+            if (!Directory.Exists(dotVsDirectory))
+                Directory.CreateDirectory(dotVsDirectory);
+                
+            File.WriteAllText(
+                $"{dotVsDirectory}\\{SolutionSettingsFileName}",
+                JsonConvert.SerializeObject(new SolutionSettingsFile
+                {
+                    ShouldNotifyUserToCreateCodigaConfig = false
+                }));
+        }
+
+        /// <summary>
+        /// Looks up the Codiga solution settings file in the <c>.vs</c> directory located in the provided Solution's root directory,
+        /// or in the currently open folder.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider to retrieve information about the solution from.</param>
+        /// <returns>The path of the settings file, or null if the solution root, the <c>.vs</c> directory, or the settings file itself don't exist.</returns>
+        private static string? FindSolutionSettingsFile(SVsServiceProvider serviceProvider)
+        {
+            var solutionRoot = SolutionHelper.GetSolutionDir(serviceProvider);
+            if (solutionRoot == null)
+                return null;
+
+            var directories = Directory.GetDirectories(solutionRoot);
+            if (!directories.Contains($"{solutionRoot}\\.vs"))
+                return null;
+
+            var solutionSettingsFile = Directory
+                .EnumerateFiles($"{solutionRoot}\\.vs", SolutionSettingsFileName, SearchOption.TopDirectoryOnly)
+                .FirstOrDefault();
+
+            return solutionSettingsFile != null && File.Exists(solutionSettingsFile) ? solutionSettingsFile : null;
+        }
+
+        public class SolutionSettingsFile
+        {
+            public bool? ShouldNotifyUserToCreateCodigaConfig { get; set; } = true;
+        }
+    }
+}

--- a/src/GraphQLClient/CodigaClient.cs
+++ b/src/GraphQLClient/CodigaClient.cs
@@ -98,6 +98,12 @@ namespace GraphQLClient
 		/// Sends a request to Codiga that a rule fix quick fix was invoked by the user.
 		/// </summary>
 		public Task<string> RecordRuleFixAsync();
+
+		/// <summary>
+		/// Sends a request to Codiga that the Codiga config file was created by the user with default rulesets,
+		/// via the notification popup shown in <c>CodigaDefaultRulesetsInfoBarHelper</c>.
+		/// </summary>
+		public Task<string> RecordCreateCodigaYaml();
 	}
 
 	public class CodigaClient : ICodigaClient, IDisposable
@@ -219,7 +225,7 @@ namespace GraphQLClient
 			variablesDict["recipeId"] = recipeId;
 
 			var request = new GraphQLHttpRequest(QueryProvider.RecordRecipeUseMutation, variables);
-			var result = await _client.SendMutationAsync<RecordRecipeUseMutationResult>(request);
+			var result = await _client.SendMutationAsync<RecordMutationResult>(request);
 
 			ThrowOnErrors(result);
 			
@@ -295,7 +301,21 @@ namespace GraphQLClient
 			variablesDict["fingerprint"] = Fingerprint;
 
 			var request = new GraphQLHttpRequest(QueryProvider.RecordRuleFixMutation, variables);
-			var result = await _client.SendMutationAsync<RecordRuleFixMutationResult>(request);
+			var result = await _client.SendMutationAsync<RecordMutationResult>(request);
+
+			ThrowOnErrors(result);
+			
+			return result.Data.RecordAccess;
+		}
+		
+		public async Task<string> RecordCreateCodigaYaml()
+		{
+			dynamic variables = new System.Dynamic.ExpandoObject();
+			var variablesDict = (IDictionary<string, object?>)variables;
+			variablesDict["fingerprint"] = Fingerprint;
+
+			var request = new GraphQLHttpRequest(QueryProvider.RecordCreateCodigaYamlMutation, variables);
+			var result = await _client.SendMutationAsync<RecordMutationResult>(request);
 
 			ThrowOnErrors(result);
 			
@@ -367,12 +387,7 @@ namespace GraphQLClient
 		public long RuleSetsLastUpdatedTimestamp { get; set; }
 	}
 
-	internal class RecordRecipeUseMutationResult
-	{
-		public string? RecordAccess { get; set; }
-	}
-	
-	internal class RecordRuleFixMutationResult
+	internal class RecordMutationResult
 	{
 		public string? RecordAccess { get; set; }
 	}

--- a/src/GraphQLClient/GraphQLClient.csproj
+++ b/src/GraphQLClient/GraphQLClient.csproj
@@ -27,6 +27,7 @@
     <GraphQLConfig Include="queries\RecordAccess.graphql" />
     <GraphQLConfig Include="queries\RecordRecipeUse.graphql" />
     <GraphQLConfig Include="queries\RecordRuleFix.graphql" />
+    <GraphQLConfig Include="queries\RecordCreateCodigaYaml.graphql" />
     <GraphQLConfig Include="queries\GetRulesetsForClient.graphql" />
     <GraphQLConfig Include="queries\GetRulesetsForClientLastTimestamp.graphql" />
     <GraphQLConfig Include="queries\RemoveViolationToIgnore.graphql" />
@@ -47,6 +48,7 @@
   <ItemGroup>
     <AdditionalFiles Remove="queries\RecordRecipeUse.graphql" />
     <AdditionalFiles Remove="queries\RecordRuleFix.graphql" />
+    <AdditionalFiles Remove="queries\RecordCreateCodigaYaml.graphql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,6 +66,7 @@
     <None Remove="Queries\GetUser.graphql" />
     <None Remove="Queries\RecordRecipeUse.graphql" />
     <None Remove="Queries\RecordRuleFix.graphql" />
+    <None Remove="Queries\RecordCreateCodigaYaml.graphql" />
     <None Remove="Queries\GetRulesetsForClient.graphql" />
     <None Remove="Queries\GetRulesetsForClientLastTimestamp.graphql" />
   </ItemGroup>
@@ -75,6 +78,7 @@
     <EmbeddedResource Include="Queries\GetUser.graphql" />
     <EmbeddedResource Include="Queries\RecordRecipeUse.graphql" />
     <EmbeddedResource Include="Queries\RecordRuleFix.graphql" />
+    <EmbeddedResource Include="Queries\RecordCreateCodigaYaml.graphql" />
     <EmbeddedResource Include="Queries\GetRulesetsForClient.graphql" />
     <EmbeddedResource Include="Queries\GetRulesetsForClientLastTimestamp.graphql" />
   </ItemGroup>

--- a/src/GraphQLClient/Queries/RecordCreateCodigaYaml.graphql
+++ b/src/GraphQLClient/Queries/RecordCreateCodigaYaml.graphql
@@ -1,0 +1,3 @@
+mutation RecordCreateCodigaYaml($fingerprint: String) {
+  recordAccess(accessType: VisualStudio, actionType: CreateCodigaYaml, userFingerprint: $fingerprint)
+}

--- a/src/GraphQLClient/QueryProvider.cs
+++ b/src/GraphQLClient/QueryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Reflection;
+using Microsoft.VisualStudio.Threading;
 
 namespace GraphQLClient
 {
@@ -22,6 +23,7 @@ namespace GraphQLClient
 		private const string GetRulesetsForClientQueryFile = Namespace + "GetRulesetsForClient.graphql";
 		private const string GetRulesetsLastUpdatedTimestampQueryFile = Namespace + "GetRulesetsForClientLastTimestamp.graphql";
 		private const string RecordRuleFixMutationFile = Namespace + "RecordRuleFix.graphql";
+		private const string RecordCreateCodigaYamlMutationFile = Namespace + "RecordCreateCodigaYaml.graphql";
 
 		public static string ShortcutQuery { get; }
 		public static string ShortcutLastTimestampQuery { get; }
@@ -31,6 +33,7 @@ namespace GraphQLClient
 		public static string GetRulesetsForClientQuery { get; }
 		public static string GetRulesetsLastUpdatedTimestampQuery { get; }
 		public static string RecordRuleFixMutation { get; }
+		public static string RecordCreateCodigaYamlMutation { get; }
 
 		static QueryProvider()
 		{
@@ -82,6 +85,12 @@ namespace GraphQLClient
 			{
 				using StreamReader reader = new StreamReader(stream);
 				RecordRuleFixMutation = reader.ReadToEnd();
+			}
+			
+			using (Stream stream = assembly.GetManifestResourceStream(RecordCreateCodigaYamlMutationFile))
+			{
+				using StreamReader reader = new StreamReader(stream);
+				RecordCreateCodigaYamlMutation = reader.ReadToEnd();
 			}
 		}
 	}

--- a/src/Tests/Settings/SolutionSettingsTest.cs
+++ b/src/Tests/Settings/SolutionSettingsTest.cs
@@ -1,0 +1,165 @@
+using System.IO;
+using Extension.Settings;
+using Microsoft.VisualStudio.Shell;
+using NUnit.Framework;
+using static Tests.ServiceProviderMockSupport;
+
+namespace Tests.Settings
+{
+    /// <summary>
+    /// Unit test for <see cref="SolutionSettings"/>.
+    /// </summary>
+    [TestFixture]
+    public class SolutionSettingsTest
+    {
+        private string _solutionSettingsFile;
+        private string _dotVsDirectory;
+
+        #region IsShouldNotifyUserToCreateCodigaConfig
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_true_for_no_solution_root()
+        {
+            var serviceProvider = MockServiceProvider("/");
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.True);
+        }
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_true_for_no_dot_vs_in_solution_root()
+        {
+            var serviceProvider = MockServiceProvider(Path.GetTempPath());
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.True);
+        }
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_true_for_no_solution_settings_file()
+        {
+            var serviceProvider = MockServiceProvider(Path.GetTempPath());
+            _dotVsDirectory = $"{Path.GetTempPath()}.vs";
+
+            Directory.CreateDirectory(_dotVsDirectory);
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.True);
+        }
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_true_for_true_setting()
+        {
+            var serviceProvider = SetupSolutionSettingsFile("{\n    \"ShouldNotifyUserToCreateCodigaConfig\": true\n}");
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.True);
+        }
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_true_for_non_existent_property()
+        {
+            var serviceProvider = SetupSolutionSettingsFile("{\n    \"CreateCodigaConfig\": true\n}");
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.True);
+        }
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_true_for_invalid_settings()
+        {
+            var serviceProvider = SetupSolutionSettingsFile("{\n    \"CreateCodigaConfig\"");
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.True);
+        }
+
+        [Test]
+        public void IsShouldNotifyUserToCreateCodigaConfig_should_return_false_for_false_setting()
+        {
+            var serviceProvider =
+                SetupSolutionSettingsFile("{\n    \"ShouldNotifyUserToCreateCodigaConfig\": false\n}");
+
+            var isShouldNotify = SolutionSettings.IsShouldNotifyUserToCreateCodigaConfig(serviceProvider);
+
+            Assert.That(isShouldNotify, Is.False);
+        }
+
+        #endregion
+
+        #region SaveNeverNotifyUserToCreateCodigaConfigFile
+
+        [Test]
+        public void SaveNeverNotifyUserToCreateCodigaConfigFile_should_create_the_solution_settings_file_and_dot_vs()
+        {
+            var serviceProvider = MockServiceProvider(Path.GetTempPath());
+            SetupPaths();
+
+            Assert.That(Directory.Exists(_dotVsDirectory), Is.False);
+
+            SolutionSettings.SaveNeverNotifyUserToCreateCodigaConfigFile(serviceProvider);
+
+            Assert.That(File.Exists(_solutionSettingsFile), Is.True);
+            Assert.That(File.ReadAllText(_solutionSettingsFile),
+                Is.EqualTo("{\"ShouldNotifyUserToCreateCodigaConfig\":false}"));
+        }
+
+        [Test]
+        public void SaveNeverNotifyUserToCreateCodigaConfigFile_should_create_the_solution_settings_file()
+        {
+            var serviceProvider = MockServiceProvider(Path.GetTempPath());
+            SetupPaths();
+            Directory.CreateDirectory(_dotVsDirectory);
+
+            Assert.That(File.Exists(_solutionSettingsFile), Is.False);
+
+            SolutionSettings.SaveNeverNotifyUserToCreateCodigaConfigFile(serviceProvider);
+
+            Assert.That(File.Exists(_solutionSettingsFile), Is.True);
+            Assert.That(File.ReadAllText(_solutionSettingsFile),
+                Is.EqualTo("{\"ShouldNotifyUserToCreateCodigaConfig\":false}"));
+        }
+
+        [Test]
+        public void SaveNeverNotifyUserToCreateCodigaConfigFile_should_update_the_solution_settings_file()
+        {
+            var serviceProvider = SetupSolutionSettingsFile("{\n    \"ShouldNotifyUserToCreateCodigaConfig\": true\n}");
+
+            SolutionSettings.SaveNeverNotifyUserToCreateCodigaConfigFile(serviceProvider);
+
+            Assert.That(File.ReadAllText(_solutionSettingsFile),
+                Is.EqualTo("{\"ShouldNotifyUserToCreateCodigaConfig\":false}"));
+        }
+
+        #endregion
+
+        private SVsServiceProvider SetupSolutionSettingsFile(string settingsFileContent)
+        {
+            SetupPaths();
+            Directory.CreateDirectory(_dotVsDirectory);
+            File.WriteAllText(_solutionSettingsFile, settingsFileContent);
+            return MockServiceProvider(Path.GetTempPath());
+        }
+
+        private void SetupPaths()
+        {
+            _dotVsDirectory = $"{Path.GetTempPath()}.vs";
+            _solutionSettingsFile = $"{Path.GetTempPath()}.vs\\CodigaSolutionSettings.json";
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_solutionSettingsFile))
+                File.Delete(_solutionSettingsFile);
+            if (Directory.Exists(_dotVsDirectory))
+                Directory.Delete(_dotVsDirectory);
+        }
+    }
+}

--- a/src/Tests/TestCodigaClient.cs
+++ b/src/Tests/TestCodigaClient.cs
@@ -68,6 +68,11 @@ namespace Tests
             return await Task.FromResult<string>(null);
         }
 
+        public async Task<string> RecordCreateCodigaYaml()
+        {
+            return await Task.FromResult<string>(null);
+        }
+
         public void Dispose()
         {
         }


### PR DESCRIPTION
### Changes
- Added `CodigaDefaultRulesetsInfoBarHelper` and `CodigaRulesetConfigs` with the logic to display an info bar in the Solution Explorer with options to create codiga.yml or no longer show the info bar.
  - This is bound to the `SolutionEvents.OnAfterOpenSolution` event in `ExtensionPackage`.
  - Since the solution might already be open when `ExtensionPackage.InitializeAsync()` is called, it makes sure that the info bar is handled in that case too. 
- Add metric for creating codiga.yml regarding https://github.com/codiga/visualstudio-extension/issues/13.