### PR TITLE
Check for the presence of Python files when in Open Folder mode.

### DIFF
--- a/src/Extension/Helpers/SolutionHelper.cs
+++ b/src/Extension/Helpers/SolutionHelper.cs
@@ -21,5 +21,15 @@ namespace Extension.Helpers
             sol.GetSolutionInfo(out string dir, out string file, out string ops);
             return Path.GetDirectoryName(dir);
         }
+
+        /// <summary>
+        /// Returns whether the argument solution is in Open Folder mode.
+        /// </summary>
+        /// <param name="solution">The solution service</param>
+        internal static bool IsInOpenFolderMode(IVsSolution solution)
+        {
+            solution.GetProperty((int)__VSPROPID7.VSPROPID_IsInOpenFolderMode, out object folderMode);
+            return folderMode is bool isInOpenFolderMode && isInOpenFolderMode;
+        }
     }
 }


### PR DESCRIPTION
### Changes
- `ExtensionPackage`
  - Hooked in the file lookup to the `SolutionEvents.OnAfterOpenFolder` event, and its cleanup to when the folder is closed.
- `CodigaDefaultRulesetsInfoBarHelper`
  - Added a recursive lookup for Python files. It currently excludes `.vs` and `.idea` folders since they are not usually modified manually by users.