### PR TITLE
Housekeeping

### DIFF
--- a/src/Extension/AssistantCompletion/DefaultCompletionItemManager.cs
+++ b/src/Extension/AssistantCompletion/DefaultCompletionItemManager.cs
@@ -1,14 +1,13 @@
-﻿using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.PatternMatching;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Extension.AssistantCompletion
 {
@@ -44,7 +43,7 @@ namespace Extension.AssistantCompletion
             // The relevant CompletionItem is match.Item1, its PatternMatch is match.Item2
             var patternMatcher = _patternMatcherFactory.CreatePatternMatcher(
                 filterText,
-                new PatternMatcherCreationOptions(System.Globalization.CultureInfo.CurrentCulture, PatternMatcherCreationFlags.IncludeMatchedSpans));
+                new PatternMatcherCreationOptions(CultureInfo.CurrentCulture, PatternMatcherCreationFlags.IncludeMatchedSpans));
 
             var matches = data.InitialSortedItemList
 				// Perform pattern matching

--- a/src/Extension/AssistantCompletion/ExpansionClient.cs
+++ b/src/Extension/AssistantCompletion/ExpansionClient.cs
@@ -1,28 +1,21 @@
-﻿using Community.VisualStudio.Toolkit;
-using EnvDTE;
-using Extension.Caching;
-using Extension.Logging;
-using Extension.SnippetFormats;
-using GraphQLClient;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Editor;
-using Microsoft.VisualStudio.GraphModel.CodeSchema;
-using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Settings.Internal;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.TextManager.Interop;
-using MSXML;
-using System;
+﻿using System;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Windows.Media.TextFormatting;
-using System.Windows.Shapes;
 using System.Xml;
+using System.Xml.Serialization;
+using Extension.Caching;
+using Extension.Logging;
+using Extension.SnippetFormats;
+using GraphQLClient;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using MSXML;
 
 namespace Extension.AssistantCompletion
 {
@@ -86,7 +79,7 @@ namespace Extension.AssistantCompletion
 
 			// create IXMLDOMNode from snippet
 			IXMLDOMNode snippetXml;
-			var serializer = new System.Xml.Serialization.XmlSerializer(typeof(VisualStudioSnippet));
+			var serializer = new XmlSerializer(typeof(VisualStudioSnippet));
 			using (var sw = new StringWriter())
 			{
 				using var xw = XmlWriter.Create(sw, new XmlWriterSettings { Encoding = Encoding.UTF8 });
@@ -258,7 +251,6 @@ namespace Extension.AssistantCompletion
 				catch (CodigaAPIException e)
 				{
 					ExtensionLogger.LogException(e);
-					return;
 				}
 			});
 		}

--- a/src/Extension/AssistantCompletion/ShortcutCompletionCommitManagerProvider.cs
+++ b/src/Extension/AssistantCompletion/ShortcutCompletionCommitManagerProvider.cs
@@ -1,12 +1,9 @@
-﻿using Extension.Caching;
-using GraphQLClient;
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 
 namespace Extension.AssistantCompletion
 {

--- a/src/Extension/AssistantCompletion/ShortcutCompletionSourceProvider.cs
+++ b/src/Extension/AssistantCompletion/ShortcutCompletionSourceProvider.cs
@@ -1,16 +1,10 @@
-﻿using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Extension.Caching;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.Editor;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Extension.Caching;
-using System.Windows.Controls;
 
 namespace Extension.AssistantCompletion
 {

--- a/src/Extension/Caching/CodigaClientProvider.cs
+++ b/src/Extension/Caching/CodigaClientProvider.cs
@@ -1,9 +1,7 @@
-﻿using Extension.Logging;
+﻿using System;
+using Extension.Logging;
 using Extension.Settings;
 using GraphQLClient;
-using Microsoft.VisualStudio.Shell;
-using System;
-using System.ComponentModel.Composition;
 
 namespace Extension.Caching
 {

--- a/src/Extension/Caching/SnippetCache.cs
+++ b/src/Extension/Caching/SnippetCache.cs
@@ -2,14 +2,13 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Timers;
 using Extension.Logging;
 using Extension.SnippetFormats;
 using GraphQLClient;
-using Microsoft.VisualStudio.Shell;
-using CodigaSnippet = GraphQLClient.CodigaSnippet;
+using Timer = System.Timers.Timer;
 
 namespace Extension.Caching
 {
@@ -197,18 +196,18 @@ namespace Extension.Caching
 
 		public long? LastTimeStamp { get; set; }
 
-		private System.Timers.Timer IdleTimer { get; }
+		private Timer IdleTimer { get; }
 
 		public event EventHandler<EventArgs> IdleTimerElapsed;
 
 		public PollingSession()
 		{
-			IdleTimer = new System.Timers.Timer(TimeSpan.FromMinutes(SnippetCache.IdleIntervalInMinutes).TotalMilliseconds);
+			IdleTimer = new Timer(TimeSpan.FromMinutes(SnippetCache.IdleIntervalInMinutes).TotalMilliseconds);
 			IdleTimer.AutoReset = true;
 			IdleTimer.Elapsed += IdleTimer_Elapsed;
 		}
 
-		private void IdleTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+		private void IdleTimer_Elapsed(object sender, ElapsedEventArgs e)
 		{
 			IdleTimerElapsed?.Invoke(this, new EventArgs());
 		}

--- a/src/Extension/InlineCompletion/InlineCompletionClient.cs
+++ b/src/Extension/InlineCompletion/InlineCompletionClient.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -202,6 +203,7 @@ namespace Extension.InlineCompletion
 			}
 			else
 			{
+				_snippetNavigator = new ListNavigator<VisualStudioSnippet>(new List<VisualStudioSnippet>());
 				_completionView.ShowPreview = false;
 				_completionView.UpdateView(null, 0, 0);
 			}

--- a/src/Extension/InlineCompletion/SnippetNavigator.cs
+++ b/src/Extension/InlineCompletion/SnippetNavigator.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Extension.InlineCompletion
 {

--- a/src/Extension/Rosie/Annotation/RosieViolationSquiggleTagger.cs
+++ b/src/Extension/Rosie/Annotation/RosieViolationSquiggleTagger.cs
@@ -153,7 +153,7 @@ namespace Extension.Rosie.Annotation
             if (!_isDisposed)
                 TagsChanged?.Invoke(this,
                     new SnapshotSpanEventArgs(new SnapshotSpan(_sourceBuffer.CurrentSnapshot,
-                        new Span(0, _sourceBuffer.CurrentSnapshot.Length - 1))));
+                        new Span(0, _sourceBuffer.CurrentSnapshot.Length == 0 ? 0 : _sourceBuffer.CurrentSnapshot.Length - 1))));
         }
 
         /// <summary>

--- a/src/Extension/Rosie/Annotation/RosieViolationTagger.cs
+++ b/src/Extension/Rosie/Annotation/RosieViolationTagger.cs
@@ -89,7 +89,7 @@ namespace Extension.Rosie.Annotation
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 if (RosieClientProvider.TryGetClient(out var client))
-                    Annotations = await client.GetAnnotations(_sourceBuffer);
+                    Annotations = await client.GetAnnotationsAsync(_sourceBuffer);
             });
         }
 
@@ -145,7 +145,7 @@ namespace Extension.Rosie.Annotation
         {
             if (RosieClientProvider.TryGetClient(out var client))
             {
-                Annotations = await client.GetAnnotations(textView.TextBuffer);
+                Annotations = await client.GetAnnotationsAsync(textView.TextBuffer);
                 TagsChanged.Invoke(this,
                     new SnapshotSpanEventArgs(new SnapshotSpan(textView.TextBuffer.CurrentSnapshot,
                         new Span(0, textView.TextBuffer.CurrentSnapshot.Length - 1))));

--- a/src/Extension/Rosie/Annotation/RosieViolationTagger.cs
+++ b/src/Extension/Rosie/Annotation/RosieViolationTagger.cs
@@ -148,7 +148,7 @@ namespace Extension.Rosie.Annotation
                 Annotations = await client.GetAnnotationsAsync(textView.TextBuffer);
                 TagsChanged.Invoke(this,
                     new SnapshotSpanEventArgs(new SnapshotSpan(textView.TextBuffer.CurrentSnapshot,
-                        new Span(0, textView.TextBuffer.CurrentSnapshot.Length - 1))));
+                        new Span(0, textView.TextBuffer.CurrentSnapshot.Length == 0 ? 0 : textView.TextBuffer.CurrentSnapshot.Length - 1))));
                 if (RosieRulesCache.Instance != null)
                     textView.Properties[RosieRulesCache.CacheLastUpdatedTimeStampProp] =
                         RosieRulesCache.Instance.CacheLastUpdatedTimeStamp;

--- a/src/Extension/Rosie/IRosieClient.cs
+++ b/src/Extension/Rosie/IRosieClient.cs
@@ -16,6 +16,6 @@ namespace Extension.Rosie
         /// </summary>
         /// <param name="textBuffer">contains the file content to query Rosie information for</param>
         /// <returns>The list of violation information from Rosie</returns>
-        Task<IList<RosieAnnotation>> GetAnnotations(ITextBuffer textBuffer);
+        Task<IList<RosieAnnotation>> GetAnnotationsAsync(ITextBuffer textBuffer);
     }
 }

--- a/src/Extension/Rosie/Model/RosieViolation.cs
+++ b/src/Extension/Rosie/Model/RosieViolation.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Extension/Rosie/RosieClient.cs
+++ b/src/Extension/Rosie/RosieClient.cs
@@ -72,7 +72,7 @@ namespace Extension.Rosie
             };
         }
 
-        public /*override*/ async Task<IList<RosieAnnotation>> GetAnnotations(ITextBuffer textBuffer)
+        public /*override*/ async Task<IList<RosieAnnotation>> GetAnnotationsAsync(ITextBuffer textBuffer)
         {
             var fileName = _dataProvider.FileName(textBuffer);
             if (fileName == null || !File.Exists(fileName))
@@ -90,7 +90,7 @@ namespace Extension.Rosie
                 var fileText = Encoding.UTF8.GetBytes(_dataProvider.FileText(textBuffer).Replace("\r", ""));
                 var codeBase64 = Convert.ToBase64String(fileText);
 
-                await InitializeRulesCacheIfNeeded();
+                await InitializeRulesCacheIfNeededAsync();
 
                 //Prepare the request
                 var rosieRules = RosieRulesCache.Instance?.GetRosieRulesForLanguage(fileLanguage);
@@ -155,11 +155,11 @@ namespace Extension.Rosie
         /// <summary>
         /// Initializes the rules cache if it hasn't been done.
         /// <br/>
-        /// We are doing this at the first request for annotations (see <see cref="GetAnnotations"/> above), instead of on/after Solution open,
+        /// We are doing this at the first request for annotations (see <see cref="GetAnnotationsAsync"/> above), instead of on/after Solution open,
         /// since a document might be open (thus has an <c>ITextView</c> and <c>ITextBuffer</c>, and a <see cref="RosieViolationTagger"/> is created)
         /// before the Solution would open or complete opening. 
         /// </summary>
-        private async Task InitializeRulesCacheIfNeeded()
+        private async Task InitializeRulesCacheIfNeededAsync()
         {
             if (RosieRulesCache.Instance == null)
             {

--- a/src/Extension/Settings/EditorSettings.cs
+++ b/src/Extension/Settings/EditorSettings.cs
@@ -1,19 +1,11 @@
-﻿using Community.VisualStudio.Toolkit;
+﻿using System;
+using System.Linq;
+using System.Windows.Media;
+using Community.VisualStudio.Toolkit;
 using EnvDTE;
 using Extension.Settings;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Shell.Settings;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.TextManager.Interop;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media;
 
 namespace Extension
 {

--- a/src/Extension/Settings/ExtensionOptions.cs
+++ b/src/Extension/Settings/ExtensionOptions.cs
@@ -1,7 +1,5 @@
 ﻿using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
-using System;
-using System.CodeDom;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;

--- a/src/Extension/SnippetFormats/EditorUtils.cs
+++ b/src/Extension/SnippetFormats/EditorUtils.cs
@@ -1,13 +1,8 @@
 ﻿using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static Extension.SnippetFormats.LanguageUtils;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.StartPanel;
 
 namespace Extension.SnippetFormats
 {

--- a/src/Extension/SnippetFormats/VisualStudioSnippet.cs
+++ b/src/Extension/SnippetFormats/VisualStudioSnippet.cs
@@ -1,20 +1,12 @@
-﻿using Microsoft.VisualStudio.Shell.Interop;
-using MSXML;
-using Newtonsoft.Json.Linq;
-using System;
-using System.CodeDom;
-using System.Collections.Generic;
-using System.IO.Pipelines;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
-using System.Windows.Ink;
 using System.Xml;
 using System.Xml.Serialization;
 
 namespace Extension.SnippetFormats
 {
 	/// <summary>
-	/// Represents the XML snippet structure used by Viusal Studio for managing code snippets
+	/// Represents the XML snippet structure used by Visual Studio for managing code snippets
 	/// </summary>
 	[XmlRoot(ElementName = "CodeSnippets", Namespace = "http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet")]
 	public class VisualStudioSnippet

--- a/src/Extension/SnippetSearch/Preview/CodePreviewSession.cs
+++ b/src/Extension/SnippetSearch/Preview/CodePreviewSession.cs
@@ -1,10 +1,7 @@
-﻿using Extension.SnippetFormats;
-using Microsoft.VisualStudio.GraphModel.CodeSchema;
+﻿using System.Linq;
+using Extension.SnippetFormats;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using System.Linq;
-using System.Windows.Forms;
-using System.Windows.Shapes;
 
 namespace Extension.SnippetSearch.Preview
 {

--- a/src/Extension/SnippetSearch/Preview/PreviewClassifierFormat.cs
+++ b/src/Extension/SnippetSearch/Preview/PreviewClassifierFormat.cs
@@ -1,15 +1,6 @@
-﻿using Community.VisualStudio.Toolkit;
-using EnvDTE;
-using Microsoft.VisualStudio.Shell;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Diagnostics.Metrics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Extension.SnippetSearch.Preview
 {

--- a/src/Extension/SnippetSearch/SearchWindow.cs
+++ b/src/Extension/SnippetSearch/SearchWindow.cs
@@ -1,7 +1,6 @@
-﻿using Extension.SearchWindow.View;
+﻿using System.Runtime.InteropServices;
+using Extension.SearchWindow.View;
 using Microsoft.VisualStudio.Shell;
-using System;
-using System.Runtime.InteropServices;
 
 namespace Extension.SnippetSearch
 {

--- a/src/Extension/SnippetSearch/SearchWindowMenuCommand.cs
+++ b/src/Extension/SnippetSearch/SearchWindowMenuCommand.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using System;
+﻿using System;
 using System.ComponentModel.Design;
-using System.Globalization;
-using System.Threading;
 using System.Threading.Tasks;
-using Task = System.Threading.Tasks.Task;
+using Microsoft.VisualStudio.Shell;
 
 namespace Extension.SnippetSearch
 {
@@ -58,7 +54,7 @@ namespace Extension.SnippetSearch
 		/// <summary>
 		/// Gets the service provider from the owner package.
 		/// </summary>
-		private Microsoft.VisualStudio.Shell.IAsyncServiceProvider ServiceProvider
+		private IAsyncServiceProvider ServiceProvider
 		{
 			get
 			{

--- a/src/Extension/SnippetSearch/View/AsyncCommand.cs
+++ b/src/Extension/SnippetSearch/View/AsyncCommand.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
 

--- a/src/Extension/SnippetSearch/View/SnippetSearchControl.xaml.cs
+++ b/src/Extension/SnippetSearch/View/SnippetSearchControl.xaml.cs
@@ -1,8 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Windows;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 using Microsoft.Xaml.Behaviors;
-using EventTrigger = Microsoft.Xaml.Behaviors.EventTrigger;
 
 namespace Extension.SearchWindow.View
 {

--- a/src/GraphQLClient/QueryProvider.cs
+++ b/src/GraphQLClient/QueryProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Reflection;
-using Microsoft.VisualStudio.Threading;
 
 namespace GraphQLClient
 {
@@ -34,64 +33,29 @@ namespace GraphQLClient
 		public static string GetRulesetsLastUpdatedTimestampQuery { get; }
 		public static string RecordRuleFixMutation { get; }
 		public static string RecordCreateCodigaYamlMutation { get; }
-
+		
 		static QueryProvider()
 		{
 			var assembly = Assembly.GetExecutingAssembly();
 
-			using (Stream stream = assembly.GetManifestResourceStream(ShortcutQueryFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				ShortcutQuery = reader.ReadToEnd();
-			}
-
-			using (Stream stream = assembly.GetManifestResourceStream(ShortcutLastTimestampQueryFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				ShortcutLastTimestampQuery = reader.ReadToEnd();
-			}
-
-			using (Stream stream = assembly.GetManifestResourceStream(RecordRecipeUseMutationFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				RecordRecipeUseMutation = reader.ReadToEnd();
-			}
-
-			using (Stream stream = assembly.GetManifestResourceStream(SemanticQueryFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				SemanticQuery = reader.ReadToEnd();
-			}
-
-			using (Stream stream = assembly.GetManifestResourceStream(GetUserQueryFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				GetUserQuery = reader.ReadToEnd();
-			}
-			
-			using (Stream stream = assembly.GetManifestResourceStream(GetRulesetsForClientQueryFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				GetRulesetsForClientQuery = reader.ReadToEnd();
-			}
-			
-			using (Stream stream = assembly.GetManifestResourceStream(GetRulesetsLastUpdatedTimestampQueryFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				GetRulesetsLastUpdatedTimestampQuery = reader.ReadToEnd();
-			}
-			
-			using (Stream stream = assembly.GetManifestResourceStream(RecordRuleFixMutationFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				RecordRuleFixMutation = reader.ReadToEnd();
-			}
-			
-			using (Stream stream = assembly.GetManifestResourceStream(RecordCreateCodigaYamlMutationFile))
-			{
-				using StreamReader reader = new StreamReader(stream);
-				RecordCreateCodigaYamlMutation = reader.ReadToEnd();
-			}
+			ShortcutQuery = ReadQuery(assembly, ShortcutQueryFile);
+			ShortcutLastTimestampQuery = ReadQuery(assembly, ShortcutLastTimestampQueryFile);
+			RecordRecipeUseMutation = ReadQuery(assembly, RecordRecipeUseMutationFile);
+			SemanticQuery = ReadQuery(assembly, SemanticQueryFile);
+			GetUserQuery = ReadQuery(assembly, GetUserQueryFile);
+			GetRulesetsForClientQuery = ReadQuery(assembly, GetRulesetsForClientQueryFile);
+			GetRulesetsLastUpdatedTimestampQuery = ReadQuery(assembly, GetRulesetsLastUpdatedTimestampQueryFile);
+			RecordRuleFixMutation = ReadQuery(assembly, RecordRuleFixMutationFile);
+			RecordCreateCodigaYamlMutation = ReadQuery(assembly, RecordCreateCodigaYamlMutationFile);
 		}
+		
+		private static string ReadQuery(Assembly assembly, string queryFileName)
+		{
+			using (Stream stream = assembly.GetManifestResourceStream(queryFileName))
+			{
+				using StreamReader reader = new StreamReader(stream);
+				return reader.ReadToEnd();
+			}
+		} 
 	}
 }

--- a/src/Tests/Rosie/RosieClientTest.cs
+++ b/src/Tests/Rosie/RosieClientTest.cs
@@ -21,7 +21,7 @@ namespace Tests.Rosie
         {
             var rosieClient = new RosieClient(_ => null, _ => "");
 
-            var annotations = await rosieClient.GetAnnotations(new Mock<ITextBuffer>().Object);
+            var annotations = await rosieClient.GetAnnotationsAsync(new Mock<ITextBuffer>().Object);
 
             Assert.That(annotations, Is.Empty);
         }
@@ -31,7 +31,7 @@ namespace Tests.Rosie
         {
             var rosieClient = new RosieClient(_ => "", _ => "");
 
-            var annotations = await rosieClient.GetAnnotations(new Mock<ITextBuffer>().Object);
+            var annotations = await rosieClient.GetAnnotationsAsync(new Mock<ITextBuffer>().Object);
 
             Assert.That(annotations, Is.Empty);
         }
@@ -42,7 +42,7 @@ namespace Tests.Rosie
             CreateTestFile("not_supported_file_type.xaml");
             var rosieClient = new RosieClient(_ => _testFile, _ => "");
 
-            var annotations = await rosieClient.GetAnnotations(new Mock<ITextBuffer>().Object);
+            var annotations = await rosieClient.GetAnnotationsAsync(new Mock<ITextBuffer>().Object);
 
             Assert.That(annotations, Is.Empty);
         }
@@ -54,7 +54,7 @@ namespace Tests.Rosie
             var rosieClient = new RosieClient(_ => _testFile, _ => "");
             var textBuffer = new Mock<ITextBuffer>();
 
-            var annotations = await rosieClient.GetAnnotations(textBuffer.Object);
+            var annotations = await rosieClient.GetAnnotationsAsync(textBuffer.Object);
 
             Assert.That(annotations, Is.Empty);
         }


### PR DESCRIPTION
### Changes
- Deduplicated the logic in `QueryProvider`.
- Renamed some methods to include the async postfix.
- Remove unused `using` directives.
- Fixed two exceptions:
  - `RosieViolationTagger` and `RosieViolationSquiggleTagger`
    - An out of range exception occurred when the user deleted the entire content of a document.
  - `InlineCompletionClient`
    - `_snippetNavigator` was null when the commit action was invoked with no snippet to paginate. E.g. when the server didn't return any snippet for the comment keywords.