### PR TITLE
Modify VS snippet delimiter to handle Codiga snippet interference with original $ delimiter

### DIFF
--- a/src/Extension/SnippetFormats/SnippetParser.cs
+++ b/src/Extension/SnippetFormats/SnippetParser.cs
@@ -18,6 +18,34 @@ namespace Extension.SnippetFormats
 	/// </summary>
 	public static class SnippetParser
 	{
+		private static readonly Regex UserInputWithDefaultRegex =
+			new Regex(@"&\[USER_INPUT\:(?<order>\d+)(\:(?<default>[a-zA-Z0-9_]*))]");
+		private static readonly Regex UserInputWithoutDefaultRegex = new Regex(@"&\[USER_INPUT\:\d+]");
+		
+		/// <summary>
+		/// The delimiter must be single-character because in case of multi-character delimiters, the parameters are not resolved properly
+		/// upon expansion. The inserted parameter will look like e.g. <c>$!param1$!</c> for the delimiter <c>$!</c>.
+		/// <br/>
+		/// The delimiter must be a symbol that is possibly not or not often used in code. The default delimiter is <c>$</c>,
+		/// but since $ is used in many programming languages, non-snippet-parameter $ symbols in Codiga snippets would break the
+		/// expansion of the snippet.
+		/// <br/>
+		/// Although it is possible to escape $ symbols and treat them as literals by specifying them as $$, it poses problems when
+		/// we want to include multiple $ symbols in the code, so it is safer to use a different delimiter.
+		/// See https://stackoverflow.com/questions/3215705/escaping-the-character-in-snippets
+		/// </summary>
+		private const string ParameterDelimiter = "ß";
+		
+		/// <summary>
+		/// Wraps the argument parameter name with the current delimiter, e.g. <c>paramName</c> becomes <c>ßparamNameß</c>. 
+		/// </summary>
+		private static readonly Func<string, string> SnippetParameter = name => $"{ParameterDelimiter}{name}{ParameterDelimiter}";
+		
+		/// <summary>
+		/// Although <c>$end$</c> is a reserved parameter name, the delimiters in it must still match the delimiter that is set for the entire snippet.
+		/// </summary>
+		private static readonly string End = SnippetParameter("end");
+
 		/// <summary>
 		/// Creates completion items out of the provided Visual Studio snippets by adding an image and adding the snippet to the property bag.
 		/// </summary>
@@ -45,8 +73,8 @@ namespace Extension.SnippetFormats
 		/// Creates Visual Studio snippets out of the provided Codiga snippet.
 		/// Also takes care of replacing all Codiga-specific variables in the code.
 		/// </summary>
-		/// <param name="codigaSnippet"></param>
-		/// <param name="settings"></param>
+		/// <param name="codigaSnippet">Holds information about the Codiga specific snippet that is beibg converted to a VisualStudioSnippet</param>
+		/// <param name="settings">Indentation settings in the active document view</param>
 		/// <returns></returns>
 		public static VisualStudioSnippet FromCodigaSnippet(CodigaSnippet codigaSnippet, IndentationSettings settings)
 		{
@@ -80,40 +108,70 @@ namespace Extension.SnippetFormats
 			var base64bytes = Convert.FromBase64String(encoded);
 			var plainCode = Encoding.UTF8.GetString(base64bytes);
 
-			var stringBuilder = new StringBuilder(plainCode);
+			var codeWithResolvedVariables = new StringBuilder(plainCode);
 
-			ReplaceUserCaretPositions(stringBuilder);
-			ReplaceUserVariables(stringBuilder, vsSnippet);
-			ReplaceIndentation(stringBuilder, settings);
+			ReplaceUserCaretPositions(codeWithResolvedVariables);
+			ReplaceUserVariables(codeWithResolvedVariables, vsSnippet);
+			ReplaceIndentation(codeWithResolvedVariables, settings);
 
-			vsSnippet.CodeSnippet.Snippet.Code = new Code(codigaSnippet.Language, stringBuilder.ToString());
+			vsSnippet.CodeSnippet.Snippet.Code = new Code(codigaSnippet.Language, codeWithResolvedVariables.ToString(), ParameterDelimiter);
 
 			return vsSnippet;
 		}
 
 		/// <summary>
-		/// Replaces Codiga user variables [USER_INPUT:order:default] with VS literals
+		/// Replaces Codiga user variables <c>[USER_INPUT:order]</c> without default with the reserved <c>end</c> variable
+		/// as Visual Studio does not support variables without default.
+		/// <br/>
+		/// The replacement <c>end</c> variable is wrapped with the current <see cref="ParameterDelimiter"/>.
 		/// </summary>
-		/// <param name="stringBuilder"></param>
-		/// <param name="vsSnippet"></param>
-		internal static void ReplaceUserVariables(StringBuilder stringBuilder, VisualStudioSnippet vsSnippet)
+		/// <param name="codeWithResolvedVariables">Stores the code in which the Codiga user variables are replaced with VS parameters.</param>
+		internal static void ReplaceUserCaretPositions(StringBuilder codeWithResolvedVariables)
 		{
-			var plainCode = stringBuilder.ToString();
+			// Visual Studio only supports one $end$ variable
+			// which sets the selection at the end of the session
+			// so $end$ does not work with multiple caret positions
+			// whitespace default does not work for VS.
 
-			var userInputRegex = new Regex(@"&\[USER_INPUT\:\d+\:[a-zA-Z0-9_]*\]");
-			var variablesMatches = userInputRegex.Matches(plainCode);
+			var plainCode = codeWithResolvedVariables.ToString();
+			var caretMatches = UserInputWithoutDefaultRegex.Matches(plainCode);
 
-			var userVariables = variablesMatches.Cast<Match>().Select(m => {
+			// if the snippet does not define the cursor position after the session we set it to the end
+			if(caretMatches.Count == 0)
+			{
+				codeWithResolvedVariables.Append(End);
+			}
 
-				var parts = m.Value.Split(':');
+			foreach (Match match in caretMatches)
+			{
+				codeWithResolvedVariables.Replace(match.Value, End);
+			}
+		}
 
-				return new CodigaUserVariable
+		/// <summary>
+		/// Replaces Codiga user variables <c>[USER_INPUT:order:default]</c> with Visual Studio snippet specific literals,
+		/// like <c>ßparam1ß</c> based on the current <see cref="ParameterDelimiter"/>.
+		/// <br/>
+		/// The indexing in the param name is coming from the order part of the USER_INPUT variable. For example in case of
+		/// <c>[USER_INPUT:2:default value]</c> the param name is <c>param2</c>.
+		/// <br/>
+		/// This method doesn't handle the case when the default value is missing because it is handled before calling this method,
+		/// in <see cref="ReplaceUserCaretPositions"/>.
+		/// </summary>
+		/// <param name="codeWithResolvedVariables">Stores the code in which the Codiga user variables are replaced with VS parameters.</param>
+		/// <param name="vsSnippet">The snippet based on which expansion will happen</param>
+		internal static void ReplaceUserVariables(StringBuilder codeWithResolvedVariables, VisualStudioSnippet vsSnippet)
+		{
+			var plainCode = codeWithResolvedVariables.ToString();
+			var variablesMatches = UserInputWithDefaultRegex.Matches(plainCode);
+
+			var userVariables = variablesMatches.Cast<Match>().Select(m => 
+				new CodigaUserVariable
 				{
-					Order = int.Parse(parts[1]),
-					Default = parts[2].Substring(0, parts[2].Length - 1),
-					PlaceholderText = m.Value
-				};
-			}).OrderBy(v => v.Order);
+					Order = int.Parse(m.Groups["order"].Value),
+					Default = m.Groups["default"].Value.Substring(0, m.Groups["default"].Value.Length),
+					PlaceholderText = m.Value //The entire text of the user variable e.g. &[USER_INPUT:2:value]
+				}).OrderBy(v => v.Order);
 
 			// add literals and replace placeholder text
 			foreach (var variable in userVariables)
@@ -124,67 +182,40 @@ namespace Extension.SnippetFormats
 					Default = variable.Default
 				};
 
+				//If the snippet parameter is not yet added to the snippet, add it
 				if (!vsSnippet.CodeSnippet.Snippet.Declarations.Any(l => l.ID == literal.ID))
 					vsSnippet.CodeSnippet.Snippet.Declarations.Add(literal);
 
-				stringBuilder.Replace(variable.PlaceholderText, $"${literal.ID}$");
+				codeWithResolvedVariables.Replace(variable.PlaceholderText, SnippetParameter(literal.ID));
 			}
 		}
 
 		/// <summary>
-		/// Replaces Codiga user variables [USER_INPUT:order] without default with VS $end$
-		/// as Visual Studio does not support variables without default.
+		/// Replaces Codiga Indentation <c>&[CODIGA_INDENT]</c> with indentation from the editor settings.
+		/// Currently only supports 3 levels of indentation.
 		/// </summary>
-		/// <param name="stringBuilder"></param>
-		internal static void ReplaceUserCaretPositions(StringBuilder stringBuilder)
+		/// <param name="codeWithResolvedVariables">Stores the code in which the Codiga user variables are replaced with VS parameters.</param>
+		/// <param name="settings">Indentation settings in the active document view</param>
+		internal static void ReplaceIndentation(StringBuilder codeWithResolvedVariables, IndentationSettings settings)
 		{
-			// Visual Studio only supports one $end$ variable
-			// which sets the selection at the end of the session
-			// so $end$ does not work with multiple caret positions
-			// whitespace default does not work for VS.
-
-			var plainCode = stringBuilder.ToString();
-			var userCaretRegex = new Regex(@"&\[USER_INPUT\:\d+\]");
-			var caretMatches = userCaretRegex.Matches(plainCode);
-
-			// if the snippet does not define the cursor position after the session we set it to the end
-			if(caretMatches.Count == 0)
-			{
-				stringBuilder.Append("$end$");
-			}
-
-			foreach (Match match in caretMatches)
-			{
-				stringBuilder.Replace(match.Value, "$end$");
-			}
-		}
-
-		/// <summary>
-		/// Replaces Codiga Indention &[CODIGA_INDENT] with indention from the editor settings.
-		/// Currently only supports 3 levels of indention.
-		/// </summary>
-		/// <param name="stringBuilder"></param>
-		/// <param name="settings"></param>
-		internal static void ReplaceIndentation(StringBuilder stringBuilder, IndentationSettings settings)
-		{
-			// Visual Studio supports defining tab size and indent size seperatly
+			// Visual Studio supports defining tab size and indent size separately
 			// so one codiga indent can not always be replaced with one VS indent 1:1
 
 			var vsIndentLevel1 = EditorUtils.GetIndent(1, settings);
 			var vsIndentLevel2 = EditorUtils.GetIndent(2, settings);
 			var vsIndentLevel3 = EditorUtils.GetIndent(3, settings);
 
-			stringBuilder.Replace("&[CODIGA_INDENT]&[CODIGA_INDENT]&[CODIGA_INDENT]", vsIndentLevel3);
-			stringBuilder.Replace("&[CODIGA_INDENT]&[CODIGA_INDENT]", vsIndentLevel2);
-			stringBuilder.Replace("&[CODIGA_INDENT]", vsIndentLevel1);
+			codeWithResolvedVariables.Replace("&[CODIGA_INDENT]&[CODIGA_INDENT]&[CODIGA_INDENT]", vsIndentLevel3);
+			codeWithResolvedVariables.Replace("&[CODIGA_INDENT]&[CODIGA_INDENT]", vsIndentLevel2);
+			codeWithResolvedVariables.Replace("&[CODIGA_INDENT]", vsIndentLevel1);
 		}
 
 		/// <summary>
 		/// Gets the snippet code string and replaces all VS literals with their default value
 		/// so that the preview is valid code.
 		/// </summary>
-		/// <param name="vsSnippetCode"></param>
-		/// <returns></returns>
+		/// <param name="vsSnippet">The snippet based on which expansion will happen</param>
+		/// <returns>The preview code string</returns>
 		internal static string GetPreviewCode(VisualStudioSnippet vsSnippet)
 		{
 			var literals = vsSnippet.CodeSnippet.Snippet.Declarations;
@@ -192,9 +223,9 @@ namespace Extension.SnippetFormats
 
 			foreach (var literal in literals)
 			{
-				sb.Replace($"${literal.ID}$", literal.Default);
+				sb.Replace(SnippetParameter(literal.ID), literal.Default);
 			}
-			sb.Replace("$end$", "");
+			sb.Replace(End, "");
 
 			return sb.ToString();
 		}
@@ -203,8 +234,7 @@ namespace Extension.SnippetFormats
 		/// Parses the incoming "using" statement into a assembly name to be used in the Visual Studio Snippet. 
 		/// See https://learn.microsoft.com/en-us/visualstudio/ide/code-snippets-schema-reference?view=vs-2022#assembly-element
 		/// </summary>
-		/// <param name="codigaImport"></param>
-		/// <returns></returns>
+		/// <param name="codigaImport">Import statements</param>
 		internal static IEnumerable<Reference> GetClrReference(IReadOnlyCollection<string> codigaImport)
 		{
 			foreach (var import in codigaImport)
@@ -232,8 +262,5 @@ namespace Extension.SnippetFormats
 				Default = string.Empty;	
 			}
 		}
-
 	}
-
-	
 }

--- a/src/Extension/SnippetFormats/VisualStudioSnippet.cs
+++ b/src/Extension/SnippetFormats/VisualStudioSnippet.cs
@@ -7,6 +7,13 @@ namespace Extension.SnippetFormats
 {
 	/// <summary>
 	/// Represents the XML snippet structure used by Visual Studio for managing code snippets
+	/// <br/>
+	/// See the following documentation:
+	/// <ul>
+	/// <li>https://learn.microsoft.com/en-us/visualstudio/extensibility/walkthrough-implementing-code-snippets</li>
+	/// <li>https://learn.microsoft.com/en-us/visualstudio/ide/walkthrough-creating-a-code-snippet</li>
+	/// <li>https://learn.microsoft.com/en-us/visualstudio/ide/code-snippets-schema-reference</li>
+	/// </ul>
 	/// </summary>
 	[XmlRoot(ElementName = "CodeSnippets", Namespace = "http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet")]
 	public class VisualStudioSnippet
@@ -209,11 +216,12 @@ namespace Extension.SnippetFormats
 
 		}
 
-		public Code(string language, string codeString)
+		public Code(string language, string codeString, string parameterDelimiter)
 		{
 			RawCode = codeString;
 			CDataCode = new XmlNode[] { new XmlDocument().CreateCDataSection(codeString) };
 			Language = language;
+			Delimiter = parameterDelimiter;
 		}
 	}
 

--- a/src/Tests/SnippetFormatsTest.cs
+++ b/src/Tests/SnippetFormatsTest.cs
@@ -14,15 +14,18 @@ using NUnit.Framework;
 
 namespace Tests
 {
+	/// <summary>
+	/// Unit test for <see cref="SnippetParser"/>.
+	/// </summary>
     [TestFixture]
 	internal class SnippetFormatsTest
 	{
 		[Test]
-		[TestCase("&[USER_INPUT:0]", ExpectedResult = "$end$")]
-		[TestCase("&[USER_INPUT:0] test &[USER_INPUT:1] test &[USER_INPUT:2]", ExpectedResult = "$end$ test $end$ test $end$")]
-		[TestCase("&[USER_INPUT:0:default]", ExpectedResult = "&[USER_INPUT:0:default]$end$")]
-		[TestCase("&[USER_INPUT:0: ]", ExpectedResult = "$end$", Ignore = "Not sure how to handle yet")]
-		[TestCase("&[USER_INPsUT:0:__ ::]", ExpectedResult = "&[USER_INPsUT:0:__ ::]$end$")]
+		[TestCase("&[USER_INPUT:0]", ExpectedResult = "ßendß")]
+		[TestCase("&[USER_INPUT:0] test &[USER_INPUT:1] test &[USER_INPUT:2]", ExpectedResult = "ßendß test ßendß test ßendß")]
+		[TestCase("&[USER_INPUT:0:default]", ExpectedResult = "&[USER_INPUT:0:default]ßendß")]
+		[TestCase("&[USER_INPUT:0: ]", ExpectedResult = "ßendß", Ignore = "Not sure how to handle yet")]
+		[TestCase("&[USER_INPsUT:0:__ ::]", ExpectedResult = "&[USER_INPsUT:0:__ ::]ßendß")]
 		public string ReplaceUserCaretPositions_should_create_end_variable(string input)
 		{
 			// arrange
@@ -36,14 +39,16 @@ namespace Tests
 		}
 
 		[Test]
-		[TestCase("&[USER_INPUT:0:default]", 1, ExpectedResult = "$param0$")]
-		[TestCase("&[USER_INPUT:3:CONSTANT_NAME]", 1, ExpectedResult = "$param3$")]
+		[TestCase("&[USER_INPUT:0:default]", 1, ExpectedResult = "ßparam0ß")]
+		[TestCase("&[USER_INPUT:3:CONSTANT_NAME]", 1, ExpectedResult = "ßparam3ß")]
 		[TestCase("&[USER_INPUT:0: ]", 1, ExpectedResult = "&[USER_INPUT:0: ]", Ignore ="Not sure how to handle yet")]
-		[TestCase("&[USER_INPUT:0:default0] test &[USER_INPUT:1:default1] test &[USER_INPUT:2:default2]", 3, ExpectedResult = "$param0$ test $param1$ test $param2$")]
+		[TestCase("&[USER_INPUT:0:default0] test &[USER_INPUT:1:default1] test &[USER_INPUT:2:default2]", 3, ExpectedResult = "ßparam0ß test ßparam1ß test ßparam2ß")]
 		[TestCase("&[USER_INPUT:0]", 0, ExpectedResult = "&[USER_INPUT:0]")]
-		[TestCase("&[USER_INPUT:0:default0] test &[USER_INPUT:0:default1] test &[USER_INPUT:0:default2]", 1, ExpectedResult = "$param0$ test $param0$ test $param0$")]
-
-		public string ReplaceUserVariables_should_replace_codiga_format_with_vs_fromat_and_add_literals(string input, int literalCount)
+		[TestCase("&[USER_INPUT:0:default0] test &[USER_INPUT:0:default1] test &[USER_INPUT:0:default2]", 1, ExpectedResult = "ßparam0ß test ßparam0ß test ßparam0ß")]
+		[TestCase("console.log(`${&[USER_INPUT:1:value]}: &[USER_INPUT:1:name]`);", 1, ExpectedResult = "console.log(`${ßparam1ß}: ßparam1ß`);")]
+		[TestCase("console.log(`${&[USER_INPUT:1:value1]}: &[USER_INPUT:1:name1], ${&[USER_INPUT:2:value2]}: &[USER_INPUT:2:name2], &[USER_INPUT:3]`);", 
+			2, ExpectedResult = "console.log(`${ßparam1ß}: ßparam1ß, ${ßparam2ß}: ßparam2ß, &[USER_INPUT:3]`);")]
+		public string ReplaceUserVariables_should_replace_codiga_format_with_vs_format_and_add_literals(string input, int literalCount)
 		{
 			// arrange
 			var builder = new StringBuilder(input);
@@ -123,6 +128,8 @@ namespace Tests
 			Assert.NotNull(snippet);
 		}
 
+		#region FromCodigaSnippet
+		
 		[Test]
         public void FromCodigaSnippet_should_convert_to_VisualStudioSnippet_with_two_user_variables()
         {
@@ -176,8 +183,8 @@ namespace Tests
 			Assert.That(param2.Default, Is.EqualTo("act"));
 
 			Assert.That(vsSnippet.CodeSnippet.Snippet.Code.Language, Is.EqualTo("Csharp"));
-			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("$param1$"));
-			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("$param2$"));
+			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam1ß"));
+			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam2ß"));
         }
 
 		[Test]
@@ -233,8 +240,8 @@ namespace Tests
 			Assert.That(param2.Default, Is.EqualTo("act"));
 
 			Assert.That(vsSnippet.CodeSnippet.Snippet.Code.Language, Is.EqualTo("Csharp"));
-			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("$param1$"));
-			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("$param2$"));
+			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam1ß"));
+			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam2ß"));
 		}
 
 		[Test]
@@ -278,10 +285,59 @@ namespace Tests
 			Assert.That(param1.Default, Is.EqualTo("file_name"));
 
 			Assert.That(vsSnippet.CodeSnippet.Snippet.Code.Language, Is.EqualTo("Python"));
-			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("$param1$"));
-			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("$end$"));
+			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam1ß"));
+			Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßendß"));
 		}
 
+		[Test]
+		public void FromCodigaSnippet_should_work_with_snippet_including_original_delimiter()
+		{
+			// arrange
+			var snippet = new CodigaSnippet
+			{
+				Id = 89,
+				Shortcut = "console.log.multiple",
+				Name = "console log",
+				Description = "Console Log Value/Name (Multiple)",
+				Language = "JavaScript",
+				Keywords = new [] { "console", "log", "multiple" },
+				Code = Convert.ToBase64String(Encoding.UTF8.GetBytes(
+					"console.log(`${&[USER_INPUT:1:value1]}: &[USER_INPUT:1:name1], ${&[USER_INPUT:2:value2]}: &[USER_INPUT:2:name2], &[USER_INPUT:3]`);"))
+			};
+
+			// act
+			var vsSnippet = SnippetParser.FromCodigaSnippet(snippet, new IndentationSettings(4, 4, false));
+
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(vsSnippet.CodeSnippet.Header.Id, Is.EqualTo(89));
+				Assert.That(vsSnippet.CodeSnippet.Header.Shortcut, Is.EqualTo("console.log.multiple"));
+				Assert.That(vsSnippet.CodeSnippet.Header.Title, Is.EqualTo("console log"));
+				Assert.That(vsSnippet.CodeSnippet.Header.Description, Is.EqualTo("Console Log Value/Name (Multiple)"));
+				Assert.That(vsSnippet.CodeSnippet.Header.Author, Is.Null);
+			});
+			
+			Assert.That(vsSnippet.CodeSnippet.Snippet.Declarations, Has.Exactly(2).Items);
+
+			Assert.Multiple(() =>
+			{
+				var param1 = vsSnippet.CodeSnippet.Snippet.Declarations.First();
+				Assert.That(param1.ID, Is.EqualTo("param1"));
+				Assert.That(param1.Default, Is.EqualTo("value1"));
+				
+				var param2 = vsSnippet.CodeSnippet.Snippet.Declarations[1];
+				Assert.That(param2.ID, Is.EqualTo("param2"));
+				Assert.That(param2.Default, Is.EqualTo("value2"));
+
+				Assert.That(vsSnippet.CodeSnippet.Snippet.Code.Language, Is.EqualTo("JavaScript"));
+				Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam1ß"));
+				Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßparam2ß"));
+				Assert.True(vsSnippet.CodeSnippet.Snippet.Code.CodeString.Contains("ßendß"));				
+			});
+		}
+		
+		#endregion
 
 		[Test]
         public void VisualStudioSnippet_should_serialize_correctly_to_xml()
@@ -315,14 +371,21 @@ namespace Tests
 		[Test]
 		public void GetPreviewCode_should_replace_all_vs_literals()
 		{
-			// arrange
-			var snippet = SnippetTestData.Snippet;
-
 			// act
-			var preview = SnippetParser.GetPreviewCode(snippet);
+			var preview = SnippetParser.GetPreviewCode(SnippetTestData.Snippet);
 
 			// assert
 			Assert.That(preview, Is.EqualTo("MessageBox.Show(\"first\");     MessageBox.Show(\"second\");"));
+		}
+		
+		[Test]
+		public void GetPreviewCode_should_replace_all_vs_literals_including_delimiters()
+		{
+			// act
+			var preview = SnippetParser.GetPreviewCode(SnippetTestData.SnippetWithOriginalDelimiters);
+
+			// assert
+			Assert.That(preview, Is.EqualTo("console.log(`${first}: first, ${second}: second, `);"));
 		}
 
 		[Test]
@@ -377,14 +440,46 @@ namespace Tests
 								Default = "second"
 							}
 						},
-						References = new List<Reference>
+						References = new List<Reference> { new Reference { Assembly = "System.Windows.Forms.dll" } },
+						Code = new Code("CSharp", "MessageBox.Show(\"ßparam1ß\");     MessageBox.Show(\"ßparam2ß\");", "ß")
+					}
+				}
+			};
+			
+			public static VisualStudioSnippet SnippetWithOriginalDelimiters => new VisualStudioSnippet
+			{
+				CodeSnippet = new CodeSnippet
+				{
+					Format = "1.0.0",
+					
+					Header = new Header
+					{
+						Title = "Test replacement fields",
+						Shortcut = "test",
+						Description = "Code snippet for testing replacement fields",
+						Author = "MSIT",
+						SnippetTypes = new SnippetTypes { SnippetType = "Expansion" }
+					},
+
+					Snippet = new Snippet
+					{
+						Declarations = new List<Literal>
 						{
-							new Reference
+							new Literal
 							{
-								Assembly = "System.Windows.Forms.dll"
+								ID = "param1",
+								ToolTip = "First field",
+								Default = "first"
+							},
+							new Literal
+							{
+								ID = "param2",
+								ToolTip = "Second field",
+								Default = "second"
 							}
 						},
-						Code = new Code("CSharp", "MessageBox.Show(\"$param1$\");     MessageBox.Show(\"$param2$\");")
+						References = new List<Reference> { new Reference { Assembly = "System.Windows.Forms.dll" } },
+						Code = new Code("JavaScript", "console.log(`${ßparam1ß}: ßparam1ß, ${ßparam2ß}: ßparam2ß, ßendß`);", "ß")
 					}
 				}
 			};
@@ -420,8 +515,8 @@ namespace Tests
 												"               </Reference>" +
 												"            </References>" +
 												"            <Code Language=\"CSharp\">" +
-												"                <![CDATA[MessageBox.Show(\"$param1$\");" +
-												"     MessageBox.Show(\"$param2$\");]]>" +
+												"                <![CDATA[MessageBox.Show(\"ßparam1ß\");" +
+												"     MessageBox.Show(\"ßparam2ß\");]]>" +
 												"            </Code>" +
 												"        </Snippet>" +
 												"    </CodeSnippet>" +


### PR DESCRIPTION
### Changes
- `SnippetParser`
  - Extracted the USER_INPUT regexes to constants.
  - Updated the regexes and using named capturing groups to properly target each part of the USER_INPUT variables.
    - This fixes the parsing of the order part when USER_INPUT has no default value.
  - Removed the `- 1` adjustment for the default value because it cut off the last character of the default value after inserting it in the document.
  - Changed the Visual Studio snippet delimiter from `$` to `ß`, so that it no longer interferes with $ symbols in the Codiga snippets, and no longer breaks the code upon insertion.
- Improved the code documentation.