### PR TITLE
Add extra way to get the document view in inline completion

### DIFF
--- a/src/Extension/AssistantCompletion/ShortcutCompletionCommitManager.cs
+++ b/src/Extension/AssistantCompletion/ShortcutCompletionCommitManager.cs
@@ -97,16 +97,7 @@ namespace Extension.AssistantCompletion
 	        var fileName = ThreadHelper.JoinableTaskFactory.Run(async () =>
 	        {
 		        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-		        DocumentView? doc;
-		        try
-		        {
-			        doc = wpfTextView.ToDocumentView();
-		        }
-		        catch
-		        {
-			        doc = ThreadHelper.JoinableTaskFactory.Run(async () => await VS.Documents.GetActiveDocumentViewAsync());
-		        }
-
+		        var doc = EditorUtils.ToDocumentView(wpfTextView);
 		        return DocumentHelper.GetFileName(doc, wpfTextView);
 	        });
 	        

--- a/src/Extension/Caching/TextViewCreationListener.cs
+++ b/src/Extension/Caching/TextViewCreationListener.cs
@@ -34,21 +34,7 @@ namespace Extension.Caching
 		/// <param name="textView">The <see cref="IWpfTextView"/> upon which the adornment should be placed</param>
 		public void TextViewCreated(IWpfTextView textView)
 		{
-			if (textView == null)
-				return;
-
-			DocumentView doc;
-			try
-			{
-				doc = textView.ToDocumentView();
-			}
-			catch
-			{
-				doc = ThreadHelper.JoinableTaskFactory.Run(async () =>
-				{
-					return await VS.Documents.GetActiveDocumentViewAsync();
-				});
-			}
+			var doc = EditorUtils.ToDocumentView(textView);
 
 			if (doc == null)
 				return;

--- a/src/Extension/InlineCompletion/InlineCompletionClient.cs
+++ b/src/Extension/InlineCompletion/InlineCompletionClient.cs
@@ -110,7 +110,12 @@ namespace Extension.InlineCompletion
 				var triggeringLine = _wpfTextView.TextBuffer.CurrentSnapshot.GetLineFromPosition(caretPos);
 				var triggeringLineText = triggeringLine.GetText();
 				var lineTrackingSpan = _wpfTextView.TextBuffer.CurrentSnapshot.CreateTrackingSpan(triggeringLine.Extent.Span, SpanTrackingMode.EdgePositive);
-				var language = LanguageUtils.ParseFromFileName(DocumentHelper.GetFileName(_wpfTextView.ToDocumentView(), _wpfTextView));
+				
+				var doc = EditorUtils.ToDocumentView(_wpfTextView);
+				if (doc == null)
+					return _nextCommandHandler.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+				
+				var language = LanguageUtils.ParseFromFileName(DocumentHelper.GetFileName(doc, _wpfTextView));
 
 				var shouldTriggerCompletion = char.IsWhiteSpace(typedChar)
 					&& EditorUtils.IsSemanticSearchComment(triggeringLineText, language)

--- a/src/Extension/InlineCompletion/TextViewCreationListener.cs
+++ b/src/Extension/InlineCompletion/TextViewCreationListener.cs
@@ -48,18 +48,7 @@ namespace Extension.InlineCompletion
 		/// <param name="textView">The <see cref="IWpfTextView"/> upon which the adornment should be placed</param>
 		public void TextViewCreated(IWpfTextView textView)
 		{
-			if (textView == null)
-				return;
-
-			DocumentView? doc;
-			try
-			{
-				doc = textView.ToDocumentView();
-			}
-			catch
-			{
-				doc = ThreadHelper.JoinableTaskFactory.Run(async () => await VS.Documents.GetActiveDocumentViewAsync());
-			}
+			var doc = EditorUtils.ToDocumentView(textView);
 
 			if (doc == null)
 				return;

--- a/src/Extension/SnippetFormats/EditorUtils.cs
+++ b/src/Extension/SnippetFormats/EditorUtils.cs
@@ -2,6 +2,8 @@
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System.Linq;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
 using static Extension.SnippetFormats.LanguageUtils;
 
 namespace Extension.SnippetFormats
@@ -253,6 +255,27 @@ namespace Extension.SnippetFormats
 			textSpan.iEndIndex = caretIndex;
 
 			return textSpan;
+		}
+
+		/// <summary>
+		/// Converts the argument <see cref="IWpfTextView"/> to a <see cref="DocumentView"/>,
+		/// either directly, or by retrieving the currently active text and document views.
+		/// </summary>
+		/// <param name="textView">the text view to convert</param>
+		/// <returns>The DocumentView, or null if the argument IWpfTextView is null, or the DocumentView itself is null</returns>
+		public static DocumentView? ToDocumentView(IWpfTextView? textView)
+		{
+			if (textView == null)
+				return null;
+			
+			try
+			{
+				return textView.ToDocumentView();
+			}
+			catch
+			{
+				return ThreadHelper.JoinableTaskFactory.Run(async () => await VS.Documents.GetActiveDocumentViewAsync());
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Changes
- Added the `ToDocumentView()` utility method in `EditorUtils` and replaced all to `DocumentView` conversions to use this method.
  - This way `InlineCompletionClient` is also provided with an additional way of retrieving the `DocumentView`, and if it fails, then no completion is performed.
- NOTE: It is not certain that this change fixes Rollbar item 30, but it adds an extra layer of protection to try to prevent it.