### PR TITLE
Update default rulesets info bar text

### DIFF
--- a/src/Extension/Rosie/CodigaDefaultRulesetsInfoBarHelper.cs
+++ b/src/Extension/Rosie/CodigaDefaultRulesetsInfoBarHelper.cs
@@ -21,7 +21,7 @@ namespace Extension.Rosie
     public static class CodigaDefaultRulesetsInfoBarHelper
     {
         //\n characters are for better formatting of the entire content of the info bar
-        private const string InfoBarText = "Check for security, code style in your Python code with Codiga.\n";
+        private const string InfoBarText = "Check your code for security and code style issues with Codiga.\n";
         private const string CreateCodigaYmlActionText = "Create codiga.yml\n";
         private const string NeverForThisSolutionActionText = "Never for this solution";
 


### PR DESCRIPTION
### Changes
- Updated the default rulesets suggestion info bar's text to by independent of mentioning programming languages.