### PR TITLE
Handle if caret is after the end offset of the buffer

### DIFF
--- a/src/Extension/SnippetSearch/Preview/CodePreviewSession.cs
+++ b/src/Extension/SnippetSearch/Preview/CodePreviewSession.cs
@@ -57,17 +57,20 @@ namespace Extension.SnippetSearch.Preview
 			}
 
 			var newSpan = new Span(caretBufferPosition, indentedCode.Length);
-
-			// create read only region for the new snippet
-			IReadOnlyRegion newRegion;
-			using (var readEdit = textView.TextBuffer.CreateReadOnlyRegionEdit())
+			//If the caret, for some reason, happens to be after the end of the current text buffer,
+			// then we don't show the preview.
+			if (caretBufferPosition <= textView.TextBuffer.CurrentSnapshot.Length)
 			{
-				newRegion = readEdit.CreateReadOnlyRegion(newSpan);
+				// create read only region for the new snippet
+				IReadOnlyRegion newRegion;
+				using (var readEdit = textView.TextBuffer.CreateReadOnlyRegionEdit())
+				{
+					newRegion = readEdit.CreateReadOnlyRegion(newSpan);
+					readEdit.Apply();
+				}
 
-				readEdit.Apply();
+				CurrentPreview = newRegion;
 			}
-
-			CurrentPreview = newRegion;
 		}
 
 		public void StopPreviewing(IWpfTextView textView)


### PR DESCRIPTION
### Changes
- Added a condition to not show a snippet preview if the caret offset happens to be after the end of the current text buffer.